### PR TITLE
Persist session data outside of Stub IdP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,7 @@ dependencies {
 
     runtime 'joda-time:joda-time:2.3',
             'net.logstash.logback:logstash-logback-encoder:4.9'
+            'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.9.5'
 
     testCompile "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizard",
             "uk.gov.ida:stub-idp-saml-test:$dependencyVersions.stub_idp_saml",

--- a/src/main/java/uk/gov/ida/stub/idp/StubIdpApplication.java
+++ b/src/main/java/uk/gov/ida/stub/idp/StubIdpApplication.java
@@ -26,6 +26,7 @@ import uk.gov.ida.stub.idp.exceptions.mappers.CatchAllExceptionMapper;
 import uk.gov.ida.stub.idp.exceptions.mappers.FileNotFoundExceptionMapper;
 import uk.gov.ida.stub.idp.exceptions.mappers.IdpNotFoundExceptionMapper;
 import uk.gov.ida.stub.idp.exceptions.mappers.IdpUserNotFoundExceptionMapper;
+import uk.gov.ida.stub.idp.exceptions.mappers.SessionSerializationExceptionMapper;
 import uk.gov.ida.stub.idp.filters.NoCacheResponseFilter;
 import uk.gov.ida.stub.idp.filters.SessionCookieValueMustExistAsASessionFeature;
 import uk.gov.ida.stub.idp.filters.StubIdpCacheControlFilter;
@@ -138,6 +139,7 @@ public class StubIdpApplication extends Application<StubIdpConfiguration> {
         environment.jersey().register(IdpNotFoundExceptionMapper.class);
         environment.jersey().register(IdpUserNotFoundExceptionMapper.class);
         environment.jersey().register(FileNotFoundExceptionMapper.class);
+        environment.jersey().register(SessionSerializationExceptionMapper.class);
         environment.jersey().register(CatchAllExceptionMapper.class);
 
         //filters

--- a/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -58,11 +58,17 @@ import uk.gov.ida.stub.idp.domain.factories.IdentityProviderAssertionFactory;
 import uk.gov.ida.stub.idp.domain.factories.StubTransformersFactory;
 import uk.gov.ida.stub.idp.listeners.StubIdpsFileListener;
 import uk.gov.ida.stub.idp.repositories.AllIdpsUserRepository;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
+import uk.gov.ida.stub.idp.repositories.EidasSessionRepository;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
+import uk.gov.ida.stub.idp.repositories.IdpSessionRepository;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
 import uk.gov.ida.stub.idp.repositories.MetadataRepository;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
 import uk.gov.ida.stub.idp.repositories.UserRepository;
+import uk.gov.ida.stub.idp.repositories.jdbc.JDBIEidasSessionRepository;
+import uk.gov.ida.stub.idp.repositories.jdbc.JDBIIdpSessionRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.JDBIUserRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.UserMapper;
 import uk.gov.ida.stub.idp.saml.locators.IdpHardCodedEntityToEncryptForLocator;
@@ -121,7 +127,6 @@ public class StubIdpModule extends AbstractModule {
 
         bind(EntityToEncryptForLocator.class).to(IdpHardCodedEntityToEncryptForLocator.class).asEagerSingleton();
         bind(CountryMetadataSigningHelper.class).asEagerSingleton();
-        bind(SessionRepository.class).asEagerSingleton();
         bind(new TypeLiteral<ConcurrentMap<String, Document>>() {
         }).toInstance(new ConcurrentHashMap<>());
 
@@ -155,6 +160,9 @@ public class StubIdpModule extends AbstractModule {
         bind(StubCountryService.class);
         bind(UserService.class);
         bind(SamlResponseRedirectViewFactory.class);
+        
+        bind(new TypeLiteral<SessionRepository<IdpSession>>(){}).to(IdpSessionRepository.class);
+        bind(new TypeLiteral<SessionRepository<EidasSession>>(){}).to(EidasSessionRepository.class);
 
         bind(HmacValidator.class);
         bind(HmacDigest.class);
@@ -176,6 +184,20 @@ public class StubIdpModule extends AbstractModule {
     public UserRepository getUserRepository(StubIdpConfiguration configuration, UserMapper userMapper) {
         Jdbi jdbi = Jdbi.create(configuration.getDatabaseConfiguration().getUrl());
         return new JDBIUserRepository(jdbi, userMapper);
+    }
+    
+    @Provides
+    @Singleton
+    public IdpSessionRepository getIdpSessionRepository(StubIdpConfiguration configuration) {
+        Jdbi jdbi = Jdbi.create(configuration.getDatabaseConfiguration().getUrl());
+        return new JDBIIdpSessionRepository(jdbi);
+    }
+
+    @Provides
+    @Singleton
+    public EidasSessionRepository getEidasSessionRepository(StubIdpConfiguration configuration) {
+        Jdbi jdbi = Jdbi.create(configuration.getDatabaseConfiguration().getUrl());
+        return new JDBIEidasSessionRepository(jdbi);
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/stub/idp/domain/DatabaseIdpUser.java
+++ b/src/main/java/uk/gov/ida/stub/idp/domain/DatabaseIdpUser.java
@@ -1,6 +1,8 @@
 package uk.gov.ida.stub.idp.domain;
 
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.LocalDate;
 import uk.gov.ida.saml.core.domain.Address;
 import uk.gov.ida.saml.core.domain.AuthnContext;
@@ -23,17 +25,18 @@ public class DatabaseIdpUser implements Serializable {
     private final List<Address> addresses;
     private final AuthnContext levelOfAssurance;
 
+    @JsonCreator
     public DatabaseIdpUser(
-        String username,
-        String persistentId,
-        String password,
-        List<MatchingDatasetValue<String>> firstnames,
-        List<MatchingDatasetValue<String>> middleNames,
-        List<MatchingDatasetValue<String>> surnames,
-        Optional<MatchingDatasetValue<Gender>> gender,
-        List<MatchingDatasetValue<LocalDate>> dateOfBirths,
-        List<Address> addresses,
-        AuthnContext levelOfAssurance) {
+        @JsonProperty("username") String username,
+        @JsonProperty("persistentId") String persistentId,
+        @JsonProperty("password") String password,
+        @JsonProperty("firstnames") List<MatchingDatasetValue<String>> firstnames,
+        @JsonProperty("middleNames") List<MatchingDatasetValue<String>> middleNames,
+        @JsonProperty("surnames") List<MatchingDatasetValue<String>> surnames,
+        @JsonProperty("gender") Optional<MatchingDatasetValue<Gender>> gender,
+        @JsonProperty("dateOfBirths") List<MatchingDatasetValue<LocalDate>> dateOfBirths,
+        @JsonProperty("addresses") List<Address> addresses,
+        @JsonProperty("levelOfAssurance") AuthnContext levelOfAssurance) {
 
         this.username = username;
         this.persistentId = persistentId;

--- a/src/main/java/uk/gov/ida/stub/idp/domain/EidasAddress.java
+++ b/src/main/java/uk/gov/ida/stub/idp/domain/EidasAddress.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.stub.idp.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.glassfish.jersey.internal.util.Base64;
 
 import java.text.MessageFormat;
@@ -15,7 +17,8 @@ public class EidasAddress {
     private final String adminunitSecondLine;
     private final String postCode;
 
-    public EidasAddress(String poBox, String locatorDesignator, String locatorName, String cvAddressArea, String thoroughfare, String postName, String adminunitFirstLine, String adminunitSecondLine, String postCode) {
+    @JsonCreator
+    public EidasAddress(@JsonProperty("poBox") String poBox, @JsonProperty("locatorDesignator") String locatorDesignator, @JsonProperty("locatorName") String locatorName, @JsonProperty("cvAddressArea") String cvAddressArea, @JsonProperty("thoroughfare") String thoroughfare, @JsonProperty("postName") String postName, @JsonProperty("adminunitFirstLine") String adminunitFirstLine, @JsonProperty("adminunitSecondLine") String adminunitSecondLine, @JsonProperty("postCode") String postCode) {
         this.poBox = poBox;
         this.locatorDesignator = locatorDesignator;
         this.locatorName = locatorName;
@@ -82,5 +85,28 @@ public class EidasAddress {
             return MessageFormat.format("<eidas:{0}>{1}</eidas:{0}>", samlTag, value);
         }
         return "";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EidasAddress)) return false;
+
+        EidasAddress that = (EidasAddress) o;
+
+        if (poBox != null ? !poBox.equals(that.poBox) : that.poBox != null) return false;
+        if (locatorDesignator != null ? !locatorDesignator.equals(that.locatorDesignator) : that.locatorDesignator != null)
+            return false;
+        if (locatorName != null ? !locatorName.equals(that.locatorName) : that.locatorName != null) return false;
+        if (cvAddressArea != null ? !cvAddressArea.equals(that.cvAddressArea) : that.cvAddressArea != null)
+            return false;
+        if (thoroughfare != null ? !thoroughfare.equals(that.thoroughfare) : that.thoroughfare != null) return false;
+        if (postName != null ? !postName.equals(that.postName) : that.postName != null) return false;
+        if (adminunitFirstLine != null ? !adminunitFirstLine.equals(that.adminunitFirstLine) : that.adminunitFirstLine != null)
+            return false;
+        if (adminunitSecondLine != null ? !adminunitSecondLine.equals(that.adminunitSecondLine) : that.adminunitSecondLine != null)
+            return false;
+        return postCode != null ? postCode.equals(that.postCode) : that.postCode == null;
+
     }
 }

--- a/src/main/java/uk/gov/ida/stub/idp/domain/EidasAuthnRequest.java
+++ b/src/main/java/uk/gov/ida/stub/idp/domain/EidasAuthnRequest.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.stub.idp.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import uk.gov.ida.saml.core.extensions.RequestedAttribute;
@@ -18,7 +20,8 @@ public class EidasAuthnRequest {
     private final String requestedLoa;
     private final List<RequestedAttribute> attributes;
 
-    public EidasAuthnRequest(String requestId, String issuer, String destination, String requestedLoa, List<RequestedAttribute> attributes) {
+    @JsonCreator
+    public EidasAuthnRequest(@JsonProperty("requestId") String requestId, @JsonProperty("issuer") String issuer, @JsonProperty("destination") String destination, @JsonProperty("requestedLoa") String requestedLoa, @JsonProperty("attributes") List<RequestedAttribute> attributes) {
         this.requestId = requestId;
         this.issuer = issuer;
         this.destination = destination;

--- a/src/main/java/uk/gov/ida/stub/idp/domain/EidasUser.java
+++ b/src/main/java/uk/gov/ida/stub/idp/domain/EidasUser.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.stub.idp.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.LocalDate;
 import uk.gov.ida.saml.core.domain.Gender;
 
@@ -14,8 +16,9 @@ public class EidasUser {
     private EidasAddress address;
     private Gender gender;
 
-    public EidasUser(String firstName, String familyName, String persistentId,
-                     LocalDate dateOfBirth, EidasAddress address, Gender gender) {
+    @JsonCreator
+    public EidasUser(@JsonProperty("firstName") String firstName, @JsonProperty("familyName") String familyName, @JsonProperty("persistentId") String persistentId,
+                     @JsonProperty("dateOfBirth") LocalDate dateOfBirth, @JsonProperty("address") EidasAddress address, @JsonProperty("gender") Gender gender) {
         this.firstName = firstName;
         this.familyName = familyName;
         this.persistentId = persistentId;
@@ -54,5 +57,22 @@ public class EidasUser {
 
     public void setGender(Gender gender) {
         this.gender = gender;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EidasUser)) return false;
+
+        EidasUser eidasUser = (EidasUser) o;
+
+        if (firstName != null ? !firstName.equals(eidasUser.firstName) : eidasUser.firstName != null) return false;
+        if (familyName != null ? !familyName.equals(eidasUser.familyName) : eidasUser.familyName != null) return false;
+        if (persistentId != null ? !persistentId.equals(eidasUser.persistentId) : eidasUser.persistentId != null)
+            return false;
+        if (dateOfBirth != null ? !dateOfBirth.equals(eidasUser.dateOfBirth) : eidasUser.dateOfBirth != null)
+            return false;
+        if (address != null ? !address.equals(eidasUser.address) : eidasUser.address != null) return false;
+        return gender != null ? gender.equals(eidasUser.gender) : eidasUser.gender == null;
     }
 }

--- a/src/main/java/uk/gov/ida/stub/idp/domain/IdpUser.java
+++ b/src/main/java/uk/gov/ida/stub/idp/domain/IdpUser.java
@@ -110,4 +110,25 @@ public class IdpUser implements Serializable{
                 databaseIdpUser.getLevelOfAssurance()
         );
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IdpUser)) return false;
+
+        IdpUser idpUser = (IdpUser) o;
+
+        if (username != null ? !username.equals(idpUser.username) : idpUser.username != null) return false;
+        if (persistentId != null ? !persistentId.equals(idpUser.persistentId) : idpUser.persistentId != null)
+            return false;
+        if (password != null ? !password.equals(idpUser.password) : idpUser.password != null) return false;
+        if (firstnames != null ? !firstnames.equals(idpUser.firstnames) : idpUser.firstnames != null) return false;
+        if (middleNames != null ? !middleNames.equals(idpUser.middleNames) : idpUser.middleNames != null) return false;
+        if (surnames != null ? !surnames.equals(idpUser.surnames) : idpUser.surnames != null) return false;
+        if (gender != null ? !gender.equals(idpUser.gender) : idpUser.gender != null) return false;
+        if (dateOfBirths != null ? !dateOfBirths.equals(idpUser.dateOfBirths) : idpUser.dateOfBirths != null)
+            return false;
+        if (addresses != null ? !addresses.equals(idpUser.addresses) : idpUser.addresses != null) return false;
+        return levelOfAssurance == idpUser.levelOfAssurance;
+    }
 }

--- a/src/main/java/uk/gov/ida/stub/idp/exceptions/SessionSerializationException.java
+++ b/src/main/java/uk/gov/ida/stub/idp/exceptions/SessionSerializationException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.stub.idp.exceptions;
+
+public class SessionSerializationException extends RuntimeException {
+	public SessionSerializationException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/uk/gov/ida/stub/idp/exceptions/mappers/SessionSerializationExceptionMapper.java
+++ b/src/main/java/uk/gov/ida/stub/idp/exceptions/mappers/SessionSerializationExceptionMapper.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.stub.idp.exceptions.mappers;
+
+import uk.gov.ida.stub.idp.exceptions.SessionSerializationException;
+import uk.gov.ida.stub.idp.views.ErrorPageView;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class SessionSerializationExceptionMapper implements ExceptionMapper<SessionSerializationException> {
+	@Override
+	public Response toResponse(SessionSerializationException exception) {
+		return Response
+				.status(Response.Status.INTERNAL_SERVER_ERROR)
+				.entity(new ErrorPageView())
+				.build();
+	}
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/EidasSession.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/EidasSession.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.stub.idp.repositories;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
+import uk.gov.ida.stub.idp.domain.EidasUser;
+import uk.gov.ida.stub.idp.domain.IdpHint;
+import uk.gov.ida.stub.idp.domain.IdpLanguageHint;
+
+import java.util.List;
+import java.util.Optional;
+
+public class EidasSession extends Session {
+	private final EidasAuthnRequest eidasAuthnRequest;
+	private Optional<EidasUser> eidasUser = Optional.empty();
+
+	@JsonCreator
+	public EidasSession(@JsonProperty("sessionId") SessionId sessionId, @JsonProperty("eidasAuthnRequest") EidasAuthnRequest eidasAuthnRequest, @JsonProperty("relayState") String relayState,
+				   @JsonProperty("validHints") List<IdpHint> validHints, @JsonProperty("invalidHints") List<String> invalidHints, @JsonProperty("languageHint") Optional<IdpLanguageHint> languageHint, @JsonProperty("registration") Optional<Boolean> registration) {
+		super(sessionId, relayState, validHints, invalidHints, languageHint, registration);
+		this.eidasAuthnRequest = eidasAuthnRequest;
+	}
+
+	public EidasAuthnRequest getEidasAuthnRequest() {
+		return eidasAuthnRequest;
+	}
+	
+	public Optional<EidasUser> getEidasUser() {
+		return eidasUser;
+	}
+
+	public void setEidasUser(EidasUser eidasUser) {
+		this.eidasUser = Optional.ofNullable(eidasUser);
+	}
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/EidasSessionRepository.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/EidasSessionRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.stub.idp.repositories;
+
+import uk.gov.ida.common.SessionId;
+
+public interface EidasSessionRepository extends SessionRepository<EidasSession> {
+	SessionId createSession(EidasSession session);
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/IdpSession.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/IdpSession.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.stub.idp.repositories;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
+import uk.gov.ida.stub.idp.domain.IdpHint;
+import uk.gov.ida.stub.idp.domain.IdpLanguageHint;
+
+import java.util.List;
+import java.util.Optional;
+
+public class IdpSession extends Session {
+	private final IdaAuthnRequestFromHub idaAuthnRequestFromHub;
+	private Optional<DatabaseIdpUser> idpUser = Optional.empty();
+
+	@JsonCreator
+	public IdpSession(@JsonProperty("sessionId") SessionId sessionId, @JsonProperty("idaAuthnRequestFromHub") IdaAuthnRequestFromHub idaAuthnRequestFromHub, @JsonProperty("relayState") String relayState,
+				   @JsonProperty("validHints") List<IdpHint> validHints, @JsonProperty("invalidHints") List<String> invalidHints, @JsonProperty("languageHint") Optional<IdpLanguageHint> languageHint, @JsonProperty("registration") Optional<Boolean> registration) {
+		super(sessionId, relayState, validHints, invalidHints, languageHint, registration);
+		this.idaAuthnRequestFromHub = idaAuthnRequestFromHub;
+	}
+
+	public IdaAuthnRequestFromHub getIdaAuthnRequestFromHub() {
+		return idaAuthnRequestFromHub;
+	}
+
+	public Optional<DatabaseIdpUser> getIdpUser() {
+		return idpUser;
+	}
+	
+	public void setIdpUser(Optional<DatabaseIdpUser> idpUser) {
+		this.idpUser = idpUser;
+	}
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/IdpSessionRepository.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/IdpSessionRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.stub.idp.repositories;
+
+import uk.gov.ida.common.SessionId;
+
+public interface IdpSessionRepository extends SessionRepository<IdpSession> {
+	SessionId createSession(IdpSession session);
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/Session.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/Session.java
@@ -1,46 +1,27 @@
 package uk.gov.ida.stub.idp.repositories;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.ida.common.SessionId;
-import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
-import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
-import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
-import uk.gov.ida.stub.idp.domain.EidasUser;
 import uk.gov.ida.stub.idp.domain.IdpHint;
 import uk.gov.ida.stub.idp.domain.IdpLanguageHint;
 
 import java.util.List;
 import java.util.Optional;
 
-public class Session {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class Session {
 
     private final SessionId sessionId;
-    private Optional<DatabaseIdpUser> idpUser = Optional.empty();
-    private Optional<EidasUser> eidasUser = Optional.empty();
     private final String relayState;
     private final List<IdpHint> validHints;
     private final List<String> invalidHints;
     private final Optional<IdpLanguageHint> languageHint;
     private final Optional<Boolean> registration;
-    private final IdaAuthnRequestFromHub idaAuthnRequestFromHub;
-    private final EidasAuthnRequest eidasAuthnRequest;
-
-    public Session(SessionId sessionId, IdaAuthnRequestFromHub idaAuthnRequestFromHub, String relayState,
-                   List<IdpHint> validHints, List<String> invalidHints, Optional<IdpLanguageHint> languageHint, Optional<Boolean> registration) {
+    
+    public Session(@JsonProperty("sessionId") SessionId sessionId, @JsonProperty("relayState") String relayState,
+                   @JsonProperty("validHints") List<IdpHint> validHints, @JsonProperty("invalidHints") List<String> invalidHints, @JsonProperty("languageHint") Optional<IdpLanguageHint> languageHint, @JsonProperty("registration") Optional<Boolean> registration) {
         this.sessionId = sessionId;
-        this.idaAuthnRequestFromHub = idaAuthnRequestFromHub;
-        this.eidasAuthnRequest = null;
-        this.relayState = relayState;
-        this.validHints = validHints;
-        this.invalidHints = invalidHints;
-        this.languageHint = languageHint;
-        this.registration = registration;
-    }
-
-    public Session(SessionId sessionId, EidasAuthnRequest eidasAuthnRequest, String relayState,
-                   List<IdpHint> validHints, List<String> invalidHints, Optional<IdpLanguageHint> languageHint, Optional<Boolean> registration) {
-        this.sessionId = sessionId;
-        this.eidasAuthnRequest = eidasAuthnRequest;
-        this.idaAuthnRequestFromHub = null;
         this.relayState = relayState;
         this.validHints = validHints;
         this.invalidHints = invalidHints;
@@ -52,28 +33,8 @@ public class Session {
         return sessionId;
     }
 
-    public void setIdpUser(Optional<DatabaseIdpUser> idpUser) {
-        this.idpUser = idpUser;
-    }
-
-    public void setEidasUser(EidasUser eidasUser) {
-        this.eidasUser = Optional.of(eidasUser);
-    }
-
-    public Optional<DatabaseIdpUser> getIdpUser() {
-        return idpUser;
-    }
-
-    public Optional<EidasUser> getEidasUser() {
-        return eidasUser;
-    }
-
     public String getRelayState() {
         return relayState;
-    }
-
-    public IdaAuthnRequestFromHub getIdaAuthnRequestFromHub() {
-        return idaAuthnRequestFromHub;
     }
 
     public List<IdpHint> getValidHints() {
@@ -90,9 +51,5 @@ public class Session {
 
     public Optional<Boolean> isRegistration() {
         return registration;
-    }
-
-    public EidasAuthnRequest getEidasAuthnRequest() {
-        return eidasAuthnRequest;
     }
 }

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/SessionRepository.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/SessionRepository.java
@@ -1,56 +1,13 @@
 package uk.gov.ida.stub.idp.repositories;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import uk.gov.ida.common.SessionId;
-import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
-import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
-import uk.gov.ida.stub.idp.domain.IdpHint;
-import uk.gov.ida.stub.idp.domain.IdpLanguageHint;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
-public class SessionRepository {
-
-    private Cache<SessionId, Session> sessions;
-
-    @Inject
-    public SessionRepository(@Named("sessionCacheTimeoutInMinutes") Integer sessionCacheTimeoutInMinutes) {
-        this.sessions = CacheBuilder.newBuilder()
-                .expireAfterWrite(sessionCacheTimeoutInMinutes, TimeUnit.MINUTES)
-                .build();
-    }
-
-    public Optional<Session> get(SessionId sessionToken) {
-        if (!sessions.asMap().containsKey(sessionToken)) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(sessions.asMap().get(sessionToken));
-    }
-
-    public SessionId newSession(IdaAuthnRequestFromHub idaRequestFromHub, String relayState, List<IdpHint> validHints, List<String> invalidHints, Optional<IdpLanguageHint> languageHint, Optional<Boolean> registration) {
-        SessionId idpSessionId = SessionId.createNewSessionId();
-        Session session = new Session(idpSessionId, idaRequestFromHub, relayState, validHints, invalidHints, languageHint, registration);
-        return updateSession(idpSessionId, session);
-    }
-
-    public SessionId newSession(EidasAuthnRequest eidasAuthnRequest, String relayState, Optional<IdpLanguageHint> languageHint) {
-        SessionId idpSessionId = SessionId.createNewSessionId();
-        Session session = new Session(idpSessionId, eidasAuthnRequest, relayState, Collections.emptyList(), Collections.emptyList(), languageHint, Optional.empty());
-        return updateSession(idpSessionId, session);
-    }
-
-    public SessionId updateSession(SessionId id, Session session) {
-        sessions.put(id, session);
-        return id;
-    }
-
-    public Optional<Session> deleteAndGet(SessionId sessionToken) {
-        return Optional.ofNullable(sessions.asMap().remove(sessionToken));
-    }
+public interface SessionRepository<T extends Session> {
+	boolean containsSession(SessionId sessionToken);
+	Optional<T> get(SessionId sessionToken);
+	SessionId updateSession(SessionId sessionToken, Session session);
+	void deleteSession(SessionId sessionToken);
+	Optional<T> deleteAndGet(SessionId sessionToken);
 }

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/SessionRepositoryBase.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/SessionRepositoryBase.java
@@ -1,0 +1,138 @@
+package uk.gov.ida.stub.idp.repositories;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import org.jdbi.v3.core.Jdbi;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+import uk.gov.ida.stub.idp.exceptions.SessionSerializationException;
+import uk.gov.ida.stub.idp.repositories.jdbc.mixins.AuthnContextComparisonTypeMixin;
+import uk.gov.ida.stub.idp.repositories.jdbc.mixins.GenderMixin;
+import uk.gov.ida.stub.idp.repositories.jdbc.mixins.IdaAuthnRequestFromHubMixin;
+import uk.gov.ida.stub.idp.repositories.jdbc.mixins.XmlObjectMixin;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static org.apache.commons.lang3.StringEscapeUtils.unescapeJson;
+
+public abstract class SessionRepositoryBase<T extends Session> implements SessionRepository<T> {
+    private final Jdbi jdbi;
+    private final ObjectMapper objectMapper;
+    private final Class<T> sessionType;
+
+    public SessionRepositoryBase(Class<T> sessionType, Jdbi jdbi) {
+        this.sessionType = sessionType;
+        this.jdbi = jdbi;
+        this.objectMapper = createObjectMapperForSerialization();
+    }
+    
+    public boolean containsSession(SessionId sessionToken) {
+        return jdbi.withHandle(handle -> handle.select(
+                "select count(1) from stub_idp_session where session_id = ?", sessionToken.toString())
+                .mapTo(Boolean.class)
+                .findOnly());
+    }
+    
+    public Optional<T> get(SessionId sessionToken) {
+        Optional<String> sessionData = jdbi.withHandle(handle -> handle.select(
+                "select session_data from stub_idp_session where session_id = ?", sessionToken.toString())
+                .mapTo(String.class)
+                .findFirst());
+
+        if (!sessionData.isPresent()) {
+            return Optional.empty();
+        }
+
+        try {
+            String serializedSession = sessionData.get();
+            T session = objectMapper.readValue(unescapeJson(serializedSession.substring(1, serializedSession.length() - 1)), sessionType);
+
+            return Optional.of(session);
+        } catch (JsonParseException e) {
+            return cleanupSession(sessionToken);
+        } catch (JsonMappingException e) {
+            return cleanupSession(sessionToken);
+        } catch (IOException e) {
+            return cleanupSession(sessionToken);
+        }
+    }
+    
+    public SessionId updateSession(SessionId sessionToken, Session session) {
+        try {
+            String serializedSession = objectMapper.writeValueAsString(session);
+
+            jdbi.withHandle(handle ->
+                    handle.createUpdate(
+                            "UPDATE stub_idp_session SET session_data = to_json(:sessionData), last_modified = :lastModified WHERE session_id = :sessionId")
+                            .bind("sessionId", sessionToken.toString())
+                            .bind("sessionData", serializedSession)
+                            .bind("lastModified", Instant.now())
+                            .execute());
+        } catch (JsonProcessingException e) {
+            throw new SessionSerializationException("Unable to create session update.");
+        }
+
+        return sessionToken;
+    }
+    
+    
+    public void deleteSession(SessionId sessionToken) {
+        jdbi.withHandle(handle -> handle.execute("DELETE FROM stub_idp_session WHERE session_id = ?", sessionToken.toString()));
+    }
+
+    public Optional<T> deleteAndGet(SessionId sessionToken) {
+        Optional<T> session = get(sessionToken);
+        deleteSession(sessionToken);
+
+        return session;
+    }
+    
+    protected SessionId insertSession(SessionId sessionToken, T session) {
+        try {
+            String serializedSession = objectMapper.writeValueAsString(session);
+
+            jdbi.withHandle(handle ->
+                handle.createUpdate(
+                        "INSERT INTO stub_idp_session(session_id, session_data) VALUES (:sessionId, to_json(:sessionData))")
+                        .bind("sessionId", sessionToken.toString())
+                        .bind("sessionData", serializedSession)
+                        .execute());
+        } catch (JsonProcessingException e) {
+            throw new SessionSerializationException("Unable to create session update.");
+        }
+
+        return sessionToken;
+    }
+
+    private Optional cleanupSession(SessionId sessionToken) {
+        deleteSession(sessionToken);
+
+        return Optional.empty();
+    }
+
+    private ObjectMapper createObjectMapperForSerialization() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        objectMapper.addMixIn(XMLObject.class, XmlObjectMixin.class);
+        objectMapper.addMixIn(IdaAuthnRequestFromHub.class, IdaAuthnRequestFromHubMixin.class);
+        objectMapper.addMixIn(AuthnContextComparisonTypeEnumeration.class, AuthnContextComparisonTypeMixin.class);
+        objectMapper.addMixIn(Gender.class, GenderMixin.class);
+        objectMapper.registerModule(new JodaModule());
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return objectMapper;
+    }
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIEidasSessionRepository.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIEidasSessionRepository.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.stub.idp.repositories.jdbc;
+
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
+import uk.gov.ida.stub.idp.repositories.EidasSessionRepository;
+import uk.gov.ida.stub.idp.repositories.SessionRepositoryBase;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class JDBIEidasSessionRepository extends SessionRepositoryBase<EidasSession> implements EidasSessionRepository {
+	@Inject
+	public JDBIEidasSessionRepository(Jdbi jdbi) {
+		super(EidasSession.class, jdbi);
+	}
+
+	public SessionId createSession(EidasSession session) {
+		return insertSession(session.getSessionId(), session);
+	}
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepository.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepository.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.stub.idp.repositories.jdbc;
+
+import org.jdbi.v3.core.Jdbi;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
+import uk.gov.ida.stub.idp.repositories.IdpSessionRepository;
+import uk.gov.ida.stub.idp.repositories.SessionRepositoryBase;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class JDBIIdpSessionRepository extends SessionRepositoryBase<IdpSession> implements IdpSessionRepository {
+	@Inject
+	public JDBIIdpSessionRepository(Jdbi jdbi) {
+		super(IdpSession.class, jdbi);
+	}
+
+	public SessionId createSession(IdpSession session) {
+		return insertSession(session.getSessionId(), session);
+	}
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/AuthnContextComparisonTypeMixin.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/AuthnContextComparisonTypeMixin.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.stub.idp.repositories.jdbc.mixins;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public abstract class AuthnContextComparisonTypeMixin {
+	@JsonCreator
+	AuthnContextComparisonTypeMixin(@JsonProperty("comparisonType") String comparisonType) { }
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/GenderMixin.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/GenderMixin.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.stub.idp.repositories.jdbc.mixins;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public abstract class GenderMixin {
+	@JsonCreator
+	GenderMixin(@JsonProperty("value") String value) { }
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/IdaAuthnRequestFromHubMixin.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/IdaAuthnRequestFromHubMixin.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.stub.idp.repositories.jdbc.mixins;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class IdaAuthnRequestFromHubMixin {
+	@JsonCreator
+	IdaAuthnRequestFromHubMixin(
+			@JsonProperty("id") String id,
+			@JsonProperty("issuer") String issuer,
+			@JsonProperty("issueInstant") DateTime issueInstant,
+			@JsonProperty("levelsOfAssurance") List<AuthnContext> levelsOfAssurance,
+			@JsonProperty("forceAuthentication") Optional<Boolean> forceAuthentication,
+			@JsonProperty("sessionExpiryTimestamp") DateTime sessionExpiryTimestamp,
+			@JsonProperty("idpPostEndpoint") URI idpPostEndpoint,
+			@JsonProperty("comparisonType") AuthnContextComparisonTypeEnumeration comparisonType) { }
+}

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/XmlObjectMixin.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/mixins/XmlObjectMixin.java
@@ -1,0 +1,11 @@
+package uk.gov.ida.stub.idp.repositories.jdbc.mixins;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.opensaml.core.xml.schema.XSBooleanValue;
+
+import javax.annotation.Nullable;
+
+public abstract class XmlObjectMixin {
+	@JsonIgnore
+	public abstract void setNil(@Nullable final XSBooleanValue newNil);
+}

--- a/src/main/java/uk/gov/ida/stub/idp/resources/DebugPageResource.java
+++ b/src/main/java/uk/gov/ida/stub/idp/resources/DebugPageResource.java
@@ -5,10 +5,7 @@ import uk.gov.ida.common.SessionId;
 import uk.gov.ida.stub.idp.Urls;
 import uk.gov.ida.stub.idp.cookies.CookieNames;
 import uk.gov.ida.stub.idp.filters.SessionCookieValueMustExistAsASession;
-import uk.gov.ida.stub.idp.repositories.Idp;
-import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
-import uk.gov.ida.stub.idp.repositories.SessionRepository;
+import uk.gov.ida.stub.idp.repositories.*;
 import uk.gov.ida.stub.idp.views.DebugPageView;
 
 import javax.inject.Inject;
@@ -31,12 +28,12 @@ import static java.text.MessageFormat.format;
 public class DebugPageResource {
 
     private final IdpStubsRepository idpStubsRepository;
-    private final SessionRepository sessionRepository;
+    private final SessionRepository<IdpSession> sessionRepository;
 
     @Inject
     public DebugPageResource(
             IdpStubsRepository idpStubsRepository,
-            SessionRepository sessionRepository) {
+            SessionRepository<IdpSession> sessionRepository) {
         this.idpStubsRepository = idpStubsRepository;
         this.sessionRepository = sessionRepository;
     }
@@ -50,7 +47,7 @@ public class DebugPageResource {
             throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity(format(("Unable to locate session cookie for " + idpName))).build());
         }
 
-        Optional<Session> session = sessionRepository.get(sessionCookie);
+        Optional<IdpSession> session = sessionRepository.get(sessionCookie);
 
         if (!session.isPresent()) {
             throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST).entity(format(("Session is invalid for " + idpName))).build());

--- a/src/main/java/uk/gov/ida/stub/idp/resources/HeadlessIdpResource.java
+++ b/src/main/java/uk/gov/ida/stub/idp/resources/HeadlessIdpResource.java
@@ -5,8 +5,8 @@ import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.stub.idp.Urls;
 import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
 import uk.gov.ida.stub.idp.domain.SamlResponse;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.services.SuccessAuthnResponseService;
 import uk.gov.ida.stub.idp.views.SamlResponseRedirectViewFactory;
 
@@ -55,7 +55,7 @@ public class HeadlessIdpResource {
         final IdaAuthnRequestFromHub idaRequestFromHub = samlRequestTransformer.apply(samlRequest);
         final Optional<DatabaseIdpUser> idpUser = idpStubsRepository.getIdpWithFriendlyId(IDP_NAME).getUser(username, "bar");
 
-        final Session session = new Session(SessionId.createNewSessionId(), idaRequestFromHub, relayState, null, null, null, null);
+        final IdpSession session = new IdpSession(SessionId.createNewSessionId(), idaRequestFromHub, relayState, null, null, null, null);
         session.setIdpUser(idpUser);
 
         final SamlResponse successResponse = successAuthnResponseService.getSuccessResponse(false, httpServletRequest.getRemoteAddr(), IDP_NAME, session);

--- a/src/main/java/uk/gov/ida/stub/idp/services/EidasAuthnResponseService.java
+++ b/src/main/java/uk/gov/ida/stub/idp/services/EidasAuthnResponseService.java
@@ -23,8 +23,8 @@ import uk.gov.ida.stub.idp.builders.EidasResponseBuilder;
 import uk.gov.ida.stub.idp.domain.EidasAddress;
 import uk.gov.ida.stub.idp.domain.EidasUser;
 import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
 import uk.gov.ida.stub.idp.repositories.MetadataRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.saml.transformers.EidasResponseTransformerProvider;
 
 import javax.inject.Inject;
@@ -55,7 +55,7 @@ public class EidasAuthnResponseService {
         this.stubCountryMetadataUrl = stubCountryMetadataUrl;
     }
 
-    public SamlResponseFromValue<Response> getSuccessResponse(Session session, String schemeId) {
+    public SamlResponseFromValue<Response> getSuccessResponse(EidasSession session, String schemeId) {
         String issuerId = UriBuilder.fromUri(stubCountryMetadataUrl).build(schemeId).toString();
         URI hubUrl = metadataProvider.getAssertionConsumerServiceLocation();
         String requestId = session.getEidasAuthnRequest().getRequestId();
@@ -79,7 +79,7 @@ public class EidasAuthnResponseService {
         return new SamlResponseFromValue<Response>(response, eidasResponseTransformerProvider.getTransformer(), session.getRelayState(), hubUrl);
     }
 
-    public SamlResponseFromValue<Response> generateAuthnFailed(Session session, String schemeId) {
+    public SamlResponseFromValue<Response> generateAuthnFailed(EidasSession session, String schemeId) {
         String issuerId = UriBuilder.fromUri(stubCountryMetadataUrl).build(schemeId).toString();
         String requestId = session.getEidasAuthnRequest().getRequestId();
         URI hubUrl = metadataProvider.getAssertionConsumerServiceLocation();
@@ -96,7 +96,7 @@ public class EidasAuthnResponseService {
         return new SamlResponseFromValue<Response>(eidasInvalidResponse, eidasResponseTransformerProvider.getTransformer(), session.getRelayState(), hubUrl);
     }
 
-    private List<Attribute> getEidasAttributes(Session session) {
+    private List<Attribute> getEidasAttributes(EidasSession session) {
         List<RequestedAttribute> requestedAttributes = session.getEidasAuthnRequest().getAttributes();
         EidasUser user = session.getEidasUser().get();
 

--- a/src/main/java/uk/gov/ida/stub/idp/services/IdpUserService.java
+++ b/src/main/java/uk/gov/ida/stub/idp/services/IdpUserService.java
@@ -15,8 +15,8 @@ import uk.gov.ida.stub.idp.exceptions.InvalidSessionIdException;
 import uk.gov.ida.stub.idp.exceptions.InvalidUsernameOrPasswordException;
 import uk.gov.ida.stub.idp.exceptions.UsernameAlreadyTakenException;
 import uk.gov.ida.stub.idp.repositories.Idp;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 
 import javax.inject.Inject;
@@ -27,13 +27,12 @@ import java.util.UUID;
 import static java.util.Arrays.asList;
 
 public class IdpUserService {
-
-    private final SessionRepository sessionRepository;
+    private final SessionRepository<IdpSession> sessionRepository;
     private final IdpStubsRepository idpStubsRepository;
 
     @Inject
     public IdpUserService(
-            SessionRepository sessionRepository,
+            SessionRepository<IdpSession> sessionRepository,
             IdpStubsRepository idpStubsRepository) {
 
         this.sessionRepository = sessionRepository;
@@ -64,7 +63,7 @@ public class IdpUserService {
             throw new InvalidUsernameOrPasswordException();
         }
 
-        Optional<Session> session = sessionRepository.get(idpSessionId);
+        Optional<IdpSession> session = sessionRepository.get(idpSessionId);
 
         if (!session.isPresent()) {
             throw new InvalidSessionIdException();

--- a/src/main/java/uk/gov/ida/stub/idp/services/NonSuccessAuthnResponseService.java
+++ b/src/main/java/uk/gov/ida/stub/idp/services/NonSuccessAuthnResponseService.java
@@ -10,9 +10,9 @@ import uk.gov.ida.stub.idp.domain.SamlResponse;
 import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
 import uk.gov.ida.stub.idp.domain.factories.AssertionFactory;
 import uk.gov.ida.stub.idp.repositories.Idp;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
 import uk.gov.ida.stub.idp.repositories.MetadataRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.saml.transformers.OutboundResponseFromIdpTransformerProvider;
 
 import javax.inject.Inject;
@@ -47,7 +47,7 @@ public class NonSuccessAuthnResponseService {
         this.outboundResponseFromIdpTransformerProvider = outboundResponseFromIdpTransformerProvider;
     }
 
-    public SamlResponse generateFraudResponse(String idpName, String samlRequestId, FraudIndicator fraudIndicatorParam, String clientIpAddress, Session session) {
+    public SamlResponse generateFraudResponse(String idpName, String samlRequestId, FraudIndicator fraudIndicatorParam, String clientIpAddress, IdpSession session) {
         String requestId = session.getIdaAuthnRequestFromHub().getId();
         DatabaseIdpUser idpUser = IdpUserService.createRandomUser();
         Idp idp = idpStubsRepository.getIdpWithFriendlyId(idpName);

--- a/src/main/java/uk/gov/ida/stub/idp/services/StubCountryService.java
+++ b/src/main/java/uk/gov/ida/stub/idp/services/StubCountryService.java
@@ -8,7 +8,8 @@ import uk.gov.ida.stub.idp.domain.EidasAddress;
 import uk.gov.ida.stub.idp.domain.EidasUser;
 import uk.gov.ida.stub.idp.exceptions.InvalidSessionIdException;
 import uk.gov.ida.stub.idp.exceptions.InvalidUsernameOrPasswordException;
-import uk.gov.ida.stub.idp.repositories.Session;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
+import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.repositories.StubCountry;
 import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
 
@@ -18,19 +19,21 @@ import java.util.Optional;
 public class StubCountryService {
 
     private final StubCountryRepository stubCountryRepository;
+    private final SessionRepository<EidasSession> sessionRepository;
 
     @Inject
-    public StubCountryService(StubCountryRepository stubCountryRepository) {
+    public StubCountryService(StubCountryRepository stubCountryRepository, SessionRepository<EidasSession> sessionRepository) {
         this.stubCountryRepository = stubCountryRepository;
+        this.sessionRepository = sessionRepository;
     }
 
-    public void attachStubCountryToSession(String schemeName, String username, String password, Session session) throws InvalidUsernameOrPasswordException, InvalidSessionIdException {
+    public void attachStubCountryToSession(String schemeName, String username, String password, EidasSession session) throws InvalidUsernameOrPasswordException, InvalidSessionIdException {
         StubCountry stubCountry = stubCountryRepository.getStubCountryWithFriendlyId(schemeName);
         Optional<DatabaseIdpUser> user = stubCountry.getUser(username, password);
         attachEidasUserToSession(user, session);
     }
 
-    private void attachEidasUserToSession(Optional<DatabaseIdpUser> user, Session session) throws InvalidUsernameOrPasswordException, InvalidSessionIdException {
+    private void attachEidasUserToSession(Optional<DatabaseIdpUser> user, EidasSession session) throws InvalidUsernameOrPasswordException, InvalidSessionIdException {
         if (!user.isPresent()) {
             throw new InvalidUsernameOrPasswordException();
         }
@@ -41,6 +44,8 @@ public class StubCountryService {
         if (!session.getEidasUser().isPresent()) {
             throw new InvalidSessionIdException();
         }
+        
+        sessionRepository.updateSession(session.getSessionId(), session);
     }
 
     private EidasUser createEidasUser(Optional<DatabaseIdpUser> user) {

--- a/src/main/java/uk/gov/ida/stub/idp/services/SuccessAuthnResponseService.java
+++ b/src/main/java/uk/gov/ida/stub/idp/services/SuccessAuthnResponseService.java
@@ -6,15 +6,14 @@ import uk.gov.ida.saml.core.domain.PersistentId;
 import uk.gov.ida.stub.idp.StubIdpModule;
 import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
 import uk.gov.ida.stub.idp.domain.OutboundResponseFromIdp;
-import uk.gov.ida.stub.idp.domain.SamlResponse;
 import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
 import uk.gov.ida.stub.idp.domain.factories.AssertionRestrictionsFactory;
 import uk.gov.ida.stub.idp.domain.factories.IdentityProviderAssertionFactory;
 import uk.gov.ida.stub.idp.domain.factories.MatchingDatasetFactory;
 import uk.gov.ida.stub.idp.repositories.Idp;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
 import uk.gov.ida.stub.idp.repositories.MetadataRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.saml.transformers.OutboundResponseFromIdpTransformerProvider;
 
 import javax.inject.Inject;
@@ -47,7 +46,7 @@ public class SuccessAuthnResponseService {
         this.outboundResponseFromIdpTransformerProvider = outboundResponseFromIdpTransformerProvider;
     }
 
-    public SamlResponseFromValue<OutboundResponseFromIdp> getSuccessResponse(boolean randomisePid, String remoteIpAddress, String idpName, Session session) {
+    public SamlResponseFromValue<OutboundResponseFromIdp> getSuccessResponse(boolean randomisePid, String remoteIpAddress, String idpName, IdpSession session) {
         URI hubUrl = metadataProvider.getAssertionConsumerServiceLocation();
         Idp idp = idpStubsRepository.getIdpWithFriendlyId(idpName);
 

--- a/src/main/java/uk/gov/ida/stub/idp/views/DebugPageView.java
+++ b/src/main/java/uk/gov/ida/stub/idp/views/DebugPageView.java
@@ -2,7 +2,7 @@ package uk.gov.ida.stub.idp.views;
 
 import uk.gov.ida.stub.idp.domain.IdpHint;
 import uk.gov.ida.stub.idp.domain.IdpLanguageHint;
-import uk.gov.ida.stub.idp.repositories.Session;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,9 +10,9 @@ import java.util.stream.Collectors;
 
 public class DebugPageView extends IdpPageView {
 
-    private final Session session;
+    private final IdpSession session;
 
-    public DebugPageView(String name, String idpId, String assetId, Session session) {
+    public DebugPageView(String name, String idpId, String assetId, IdpSession session) {
         super("debugPage.ftl", name, idpId, null, assetId);
         this.session = session;
     }

--- a/src/main/resources/db/migrations/h2/V1__Create_Database.sql
+++ b/src/main/resources/db/migrations/h2/V1__Create_Database.sql
@@ -8,6 +8,13 @@ CREATE TABLE users (
  "data" text NOT NULL
 );
 
+CREATE TABLE stub_idp_session
+(
+	session_id varchar(36) not null primary key,
+	session_data text,
+	last_modified timestamp default now()
+);
+
 CREATE ALIAS to_json AS $$
    String to_json(String value) {
        return "{" + value + "}";

--- a/src/main/resources/db/migrations/postgres/V3__Create_Session_Table.sql
+++ b/src/main/resources/db/migrations/postgres/V3__Create_Session_Table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS stub_idp_session
+(
+	session_id varchar(36) not null primary key,
+	session_data json,
+	last_modified timestamp default now()
+)

--- a/src/test/java/uk/gov/ida/stub/idp/dtos/IdpUserDtoTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/dtos/IdpUserDtoTest.java
@@ -2,6 +2,8 @@ package uk.gov.ida.stub.idp.dtos;
 
 import io.dropwizard.jackson.Jackson;
 import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 import uk.gov.ida.saml.core.domain.Address;
@@ -14,7 +16,6 @@ import java.io.IOException;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.joda.time.DateTime.parse;
 import static uk.gov.ida.stub.idp.builders.IdpUserDtoBuilder.anIdpUserDto;
 
 public class IdpUserDtoTest {
@@ -23,7 +24,7 @@ public class IdpUserDtoTest {
     public void shouldDeSerialiseJsonToObjectWhenAllFieldsArePopulated() throws IOException {
 
         IdpUserDto idpUserDtoFromJson = Jackson.newObjectMapper().readValue("{\"pid\":\"00754148-902f-4d94-b0db-cb1f7eb3fd84\",\"username\":\"user1\",\"password\":\"password\",\"firstName\":{\"value\":\"Fred\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"middleNames\":{\"value\":\"Flintstone\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"gender\":{\"value\":\"MALE\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"dateOfBirth\":{\"value\":[1970,1,1],\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"address\":{\"verified\":false,\"from\":978307200000,\"to\":1355270400000,\"postCode\":\"WC2B 6NH\",\"lines\":[\"Aviation House\",\"London\"],\"internationalPostCode\":null,\"uprn\":null},\"levelOfAssurance\":\"LEVEL_2\",\"surnames\":[{\"value\":\"Smith\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},{\"value\":\"Henry\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true}]}", IdpUserDto.class);
-
+        
         IdpUserDto idpuserDto = anIdpUserDto()
                 .withPid("00754148-902f-4d94-b0db-cb1f7eb3fd84")
                 .withUserName("user1")
@@ -35,23 +36,23 @@ public class IdpUserDtoTest {
                 .withGender(
                         SimpleMdsValueBuilder.<Gender>aSimpleMdsValue()
                                 .withValue(Gender.MALE)
-                                .withFrom(parse("1980-01-01"))
-                                .withTo(parse("2013-01-01"))
+                                .withFrom(new DateTime(1980, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(2013, 1, 1, 0, 0, 0, DateTimeZone.UTC))
                                 .withVerifiedStatus(true)
                                 .build()
                 )
                 .withDateOfBirth(
                         SimpleMdsValueBuilder.<LocalDate>aSimpleMdsValue()
-                                .withValue(LocalDate.parse("1970-01-01"))
-                                .withFrom(parse("1980-01-01"))
-                                .withTo(parse("2013-01-01"))
+                                .withValue(new LocalDate(1970, 1, 1))
+                                .withFrom(new DateTime(1980, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(2013, 1, 1, 0, 0, 0, DateTimeZone.UTC))
                                 .withVerifiedStatus(true)
                                 .build()
                 )
                 .withAddress(
                         AddressBuilder.anAddress()
-                                .withFromDate(parse("2001-01-01"))
-                                .withToDate(parse("2012-12-12"))
+                                .withFromDate(new DateTime(2001, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                                .withToDate(new DateTime(2012, 12, 12, 0, 0, 0, DateTimeZone.UTC))
                                 .withVerified(false)
                                 .withPostCode("WC2B 6NH")
                                 .withLines(
@@ -65,10 +66,7 @@ public class IdpUserDtoTest {
                 .withLevelOfAssurance("LEVEL_2")
                 .build();
 
-
         assertThat(compareIdpUserDto(idpUserDtoFromJson,idpuserDto)).isTrue();
-
-
     }
 
     private boolean compareIdpUserDto(final IdpUserDto idpUserDtoFromJson, final IdpUserDto idpuserDto) {
@@ -143,8 +141,8 @@ public class IdpUserDtoTest {
     private MatchingDatasetValue<String> createSimpleMdsValue(String value) {
         return SimpleMdsValueBuilder.<String>aSimpleMdsValue()
                 .withValue(value)
-                .withFrom(parse("1980-01-01"))
-                .withTo(parse("2013-01-01"))
+                .withFrom(new DateTime(1980, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                .withTo(new DateTime(2013, 1, 1, 0, 0, 0, DateTimeZone.UTC))
                 .withVerifiedStatus(true)
                 .build();
     }

--- a/src/test/java/uk/gov/ida/stub/idp/filters/SessionCookieValueMustExistAsASessionFilterTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/filters/SessionCookieValueMustExistAsASessionFilterTest.java
@@ -13,7 +13,8 @@ import uk.gov.ida.stub.idp.exceptions.InvalidSecureCookieException;
 import uk.gov.ida.stub.idp.exceptions.SecureCookieNotFoundException;
 import uk.gov.ida.stub.idp.exceptions.SessionIdCookieNotFoundException;
 import uk.gov.ida.stub.idp.exceptions.SessionNotFoundException;
-import uk.gov.ida.stub.idp.repositories.Session;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -37,11 +38,11 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
     @Mock
     private HmacValidator hmacValidator;
     @Mock
-    private SessionRepository sessionRepository;
+    private SessionRepository<IdpSession> idpSessionRepository;
+    @Mock
+    private SessionRepository<EidasSession> eidasSessionRepository;
     @Mock
     private ContainerRequestContext containerRequestContext;
-    @Mock
-    private Session session;
 
     @BeforeClass
     public static void doALittleHackToMakeGuicierHappyForSomeReason() {
@@ -52,21 +53,21 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
     public void shouldReturnNullWhenCheckingNotRequiredButNoCookies() throws Exception {
         Map<String, Cookie> cookies = ImmutableMap.of();
         when(containerRequestContext.getCookies()).thenReturn(cookies);
-        new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+        new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
     @Test (expected = SecureCookieNotFoundException.class)
     public void shouldReturnNullWhenCheckingNotRequiredButSecureCookie() throws Exception {
         Map<String, Cookie> cookies = ImmutableMap.of(SESSION_COOKIE_NAME, new NewCookie(SESSION_COOKIE_NAME, "some-session-id"));
         when(containerRequestContext.getCookies()).thenReturn(cookies);
-        new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+        new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
     @Test (expected = InvalidSecureCookieException.class)
     public void shouldReturnNullWhenCheckingNotRequiredButSessionCookieIsSetToNoCurrentValue() throws Exception {
         Map<String, Cookie> cookies = ImmutableMap.of(SESSION_COOKIE_NAME, new NewCookie(SESSION_COOKIE_NAME, "some-session-id"), SECURE_COOKIE_NAME, new NewCookie(SECURE_COOKIE_NAME, NO_CURRENT_SESSION_COOKIE_VALUE));
         when(containerRequestContext.getCookies()).thenReturn(cookies);
-        new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+        new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
     @Test (expected = InvalidSecureCookieException.class)
@@ -75,7 +76,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         Map<String, Cookie> cookies = ImmutableMap.of(SESSION_COOKIE_NAME, new NewCookie(SESSION_COOKIE_NAME, sessionId.toString()), SECURE_COOKIE_NAME, new NewCookie(SECURE_COOKIE_NAME, "secure-cookie"));
         when(hmacValidator.validateHMACSHA256("secure-cookie", sessionId.getSessionId())).thenReturn(false);
         when(containerRequestContext.getCookies()).thenReturn(cookies);
-        new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+        new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
     @Test
@@ -84,8 +85,8 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         Map<String, Cookie> cookies = ImmutableMap.of(SESSION_COOKIE_NAME, new NewCookie(SESSION_COOKIE_NAME, sessionId.toString()), SECURE_COOKIE_NAME, new NewCookie(SECURE_COOKIE_NAME, "secure-cookie"));
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         when(hmacValidator.validateHMACSHA256("secure-cookie", sessionId.getSessionId())).thenReturn(true);
-        when(sessionRepository.get(sessionId)).thenReturn(Optional.ofNullable(session));
-        new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+        when(idpSessionRepository.containsSession(sessionId)).thenReturn(true);
+        new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
     @Test
@@ -93,7 +94,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         Map<String, Cookie> cookies = ImmutableMap.of();
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         try {
-            new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+            new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
             fail("we wanted an exception but we got none");
         } catch (SessionIdCookieNotFoundException e) {
             assertThat(e.getMessage()).isEqualTo("Unable to locate session from session cookie");
@@ -105,7 +106,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         Map<String, Cookie> cookies = ImmutableMap.of();
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         try {
-            new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+            new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
             fail("we wanted an exception but we got none");
         } catch (SessionIdCookieNotFoundException e) {
             assertThat(e.getMessage()).isEqualTo("Unable to locate session from session cookie");
@@ -119,7 +120,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         );
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         try {
-            new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+            new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
             fail("we wanted an exception but we got none");
         } catch (SecureCookieNotFoundException e) {
             assertThat(e.getMessage()).isEqualTo("Secure cookie not found.");
@@ -134,7 +135,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         );
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         try {
-            new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+            new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
             fail("we wanted an exception but we got none");
         } catch (InvalidSecureCookieException e) {
             assertThat(e.getMessage()).isEqualTo("Secure cookie was set to deleted session value, indicating a previously completed session.");
@@ -151,7 +152,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         when(hmacValidator.validateHMACSHA256("secure-cookie", sessionId.getSessionId())).thenReturn(false);
         try {
-            new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+            new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
             fail("we wanted an exception but we got none");
         } catch (InvalidSecureCookieException e) {
             assertThat(e.getMessage()).isEqualTo("Secure cookie value not valid.");
@@ -167,8 +168,8 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         );
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         when(hmacValidator.validateHMACSHA256("secure-cookie", sessionId.getSessionId())).thenReturn(true);
-        when(sessionRepository.get(sessionId)).thenReturn(Optional.empty());
-        new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
+        when(idpSessionRepository.get(sessionId)).thenReturn(Optional.empty());
+        new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
 
@@ -181,7 +182,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         );
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         when(hmacValidator.validateHMACSHA256("secure-cookies", sessionId.getSessionId())).thenReturn(false);
-        when(sessionRepository.get(sessionId)).thenReturn(Optional.ofNullable(session));
-        new SessionCookieValueMustExistAsASessionFilter(sessionRepository, hmacValidator, false).filter(containerRequestContext);
+        when(idpSessionRepository.containsSession(sessionId)).thenReturn(true);
+        new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, false).filter(containerRequestContext);
     }
 }

--- a/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIEidasSessionRepositoryTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIEidasSessionRepositoryTest.java
@@ -1,0 +1,71 @@
+package uk.gov.ida.stub.idp.repositories.jdbc;
+
+import org.jdbi.v3.core.Jdbi;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.stub.idp.domain.EidasAddress;
+import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
+import uk.gov.ida.stub.idp.domain.EidasUser;
+import uk.gov.ida.stub.idp.domain.IdpHint;
+import uk.gov.ida.stub.idp.domain.IdpLanguageHint;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
+import uk.gov.ida.stub.idp.repositories.jdbc.migrations.DatabaseMigrationRunner;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JDBIEidasSessionRepositoryTest {
+	private Jdbi jdbi;
+	private JDBIEidasSessionRepository repository;
+	private final String DATABASE_URL = "jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1";
+
+	@Before
+	public void setUp() {
+		new DatabaseMigrationRunner().runMigration(DATABASE_URL);
+
+		jdbi = Jdbi.create(DATABASE_URL);
+		repository = new JDBIEidasSessionRepository(jdbi);
+	}
+	
+	@Test
+	public void createSession_shouldCreateEidasSessionAndStoreInDatabase() {
+		EidasAuthnRequest authnRequest = new EidasAuthnRequest("7cb0ba32-4ebd-4291-8901-c647d4687572", "test-issuer", "", "", Arrays.asList());
+
+		SessionId eidasSessionId = SessionId.createNewSessionId();
+		EidasSession session = new EidasSession(eidasSessionId, authnRequest, "test-relay-state", Arrays.asList(IdpHint.has_ukphotolicence), Arrays.asList("invalid hint"), Optional.of(IdpLanguageHint.cy), Optional.of(true));
+		session.setEidasUser(new EidasUser("Joe", "Bloggs", "persistentId", new LocalDate(1524655440000L, DateTimeZone.UTC), new EidasAddress("PO Box 123", "", "", "", "", "", "", "", "AB1 2YZ"), Gender.MALE));
+		repository.createSession(session);
+		
+		String expectedSerializedSession = "{{\"sessionId\":\""+ eidasSessionId.getSessionId() +"\",\"eidasAuthnRequest\":{\"requestId\":\"7cb0ba32-4ebd-4291-8901-c647d4687572\",\"issuer\":\"test-issuer\",\"destination\":\"\",\"requestedLoa\":\"\",\"attributes\":[]},\"relayState\":\"test-relay-state\",\"validHints\":[\"has_ukphotolicence\"],\"invalidHints\":[\"invalid hint\"],\"languageHint\":\"cy\",\"registration\":true,\"eidasUser\":{\"firstName\":\"Joe\",\"familyName\":\"Bloggs\",\"persistentId\":\"persistentId\",\"dateOfBirth\":[2018,4,25],\"address\":{\"poBox\":\"PO Box 123\",\"locatorDesignator\":\"\",\"locatorName\":\"\",\"cvAddressArea\":\"\",\"thoroughfare\":\"\",\"postName\":\"\",\"adminunitFirstLine\":\"\",\"adminunitSecondLine\":\"\",\"postCode\":\"AB1 2YZ\"},\"gender\":\"MALE\"}}}";
+
+		jdbi.useHandle(handle -> {
+			Optional<String> result = handle.select("select session_data from stub_idp_session where session_id = ?", eidasSessionId.toString())
+					.mapTo(String.class)
+					.findFirst();
+
+			assertThat(result.isPresent()).isEqualTo(true);
+			assertThat(result.get()).isEqualTo(expectedSerializedSession);
+		});
+	}
+
+	@Test
+	public void get_shouldReturnPopulatedEidasSession_whenSessionExists() {
+		EidasAuthnRequest authnRequest = new EidasAuthnRequest("7cb0ba32-4ebd-4291-8901-c647d4687572", "test-issuer", "", "", Arrays.asList());
+
+		EidasSession expectedSession = new EidasSession(SessionId.createNewSessionId(), authnRequest, "test-relay-state", Arrays.asList(IdpHint.has_ukphotolicence), Arrays.asList("invalid hint"), Optional.of(IdpLanguageHint.cy), Optional.of(true));
+		expectedSession.setEidasUser(new EidasUser("Joe", "Bloggs", "persistentId", new LocalDate(1524655440000L, DateTimeZone.UTC), new EidasAddress("PO Box 123", "", "", "", "", "", "", "", "AB1 2YZ"), Gender.MALE));
+		SessionId insertedSessionId = repository.createSession(expectedSession);
+
+		Optional<EidasSession> actualSession = repository.get(insertedSessionId);
+
+		assertThat(actualSession.isPresent()).isEqualTo(true);
+		assertThat(actualSession.get()).isInstanceOf(EidasSession.class);
+		assertThat(actualSession.get()).isEqualToComparingFieldByFieldRecursively(expectedSession);
+	}
+}

--- a/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepositoryTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepositoryTest.java
@@ -1,0 +1,123 @@
+package uk.gov.ida.stub.idp.repositories.jdbc;
+
+import org.jdbi.v3.core.Jdbi;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import uk.gov.ida.common.SessionId;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.saml.core.domain.Gender;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
+import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
+import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
+import uk.gov.ida.stub.idp.repositories.jdbc.migrations.DatabaseMigrationRunner;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JDBIIdpSessionRepositoryTest {
+	private Jdbi jdbi;
+	private JDBIIdpSessionRepository repository;
+	private final String DATABASE_URL = "jdbc:h2:mem:test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1";
+	
+	@Before
+	public void setUp() {
+		new DatabaseMigrationRunner().runMigration(DATABASE_URL);
+
+		jdbi = Jdbi.create(DATABASE_URL);
+		repository = new JDBIIdpSessionRepository(jdbi);
+	}
+	
+	@Test
+	public void createSession_shouldCreateIdpSessionAndStoreInDatabase() {
+		DateTime authnRequestIssueTime = new DateTime(2018, 4, 25, 11, 24, 0, DateTimeZone.UTC);
+		IdaAuthnRequestFromHub authnRequest = new IdaAuthnRequestFromHub("155a37d3-5a9d-4cd0-b68a-158717b85202", "test-issuer", authnRequestIssueTime, Arrays.asList(), Optional.empty(), null, null, AuthnContextComparisonTypeEnumeration.EXACT);
+		IdpSession session = createSession(authnRequest);
+		SessionId insertedSessionId = repository.createSession(session);
+		String expectedSerializedSession = "{{\"sessionId\":\""+ insertedSessionId.getSessionId() +"\",\"idaAuthnRequestFromHub\":{\"id\":\"155a37d3-5a9d-4cd0-b68a-158717b85202\",\"issuer\":\"test-issuer\",\"issueInstant\":1524655440000,\"levelsOfAssurance\":[],\"forceAuthentication\":null,\"sessionExpiryTimestamp\":null,\"comparisonType\":{\"comparisonType\":\"exact\"},\"destination\":null},\"relayState\":\"test-relay-state\",\"validHints\":[],\"invalidHints\":[],\"languageHint\":null,\"registration\":null,\"idpUser\":{\"username\":\"jobloggs\",\"persistentId\":\"persistentId\",\"password\":\"12345678\",\"firstnames\":[{\"value\":\"Joe\",\"from\":null,\"to\":null,\"verified\":true}],\"middleNames\":[],\"surnames\":[{\"value\":\"Bloggs\",\"from\":null,\"to\":null,\"verified\":true}],\"gender\":{\"value\":\"MALE\",\"from\":null,\"to\":null,\"verified\":true},\"dateOfBirths\":[{\"value\":[2018,4,25],\"from\":null,\"to\":null,\"verified\":true}],\"addresses\":[],\"levelOfAssurance\":\"LEVEL_1\",\"currentAddress\":null}}}";
+		
+		jdbi.useHandle(handle -> {
+			Optional<String> result = handle.select("select session_data from stub_idp_session where session_id = ?", insertedSessionId.toString())
+				.mapTo(String.class)
+				.findFirst();
+				
+			assertThat(result.isPresent()).isEqualTo(true);
+			assertThat(result.get()).isEqualTo(expectedSerializedSession);
+		});
+	}
+	
+	@Test
+	public void get_shouldReturnEmptyOptional_whenSessionDoesNotExist() {
+		SessionId nonExistentSessionId = SessionId.createNewSessionId();
+		
+		Optional<IdpSession> result = repository.get(nonExistentSessionId);
+		
+		assertThat(result.isPresent()).isEqualTo(false);
+	}
+	
+	@Test
+	public void get_shouldReturnPopulatedIdpSession_whenSessionExists() {
+		DateTime authnRequestIssueTime = new DateTime(2018, 4, 25, 11, 24, 0, DateTimeZone.UTC);
+		IdaAuthnRequestFromHub authnRequest = new IdaAuthnRequestFromHub("155a37d3-5a9d-4cd0-b68a-158717b85202", "test-issuer", authnRequestIssueTime, Arrays.asList(), Optional.empty(), null, null, AuthnContextComparisonTypeEnumeration.EXACT);
+		IdpSession expectedSession = createSession(authnRequest);
+		SessionId insertedSessionId = repository.createSession(expectedSession);
+		
+		Optional<IdpSession> actualSession = repository.get(insertedSessionId);
+		
+		assertThat(actualSession.isPresent()).isEqualTo(true);
+		assertThat(actualSession.get()).isInstanceOf(IdpSession.class);
+		assertThat(actualSession.get()).isEqualToComparingFieldByFieldRecursively(expectedSession);
+	}
+	
+	@Test
+	public void updateSession_shouldNotThrowException_whenSessionDoesNotExist() {
+		DateTime authnRequestIssueTime = new DateTime(2018, 4, 25, 11, 24, 0, DateTimeZone.UTC);
+		IdaAuthnRequestFromHub authnRequest = new IdaAuthnRequestFromHub("155a37d3-5a9d-4cd0-b68a-158717b85202", "test-issuer", authnRequestIssueTime, Arrays.asList(), Optional.empty(), null, null, AuthnContextComparisonTypeEnumeration.EXACT);
+		IdpSession session = createSession(authnRequest);
+		SessionId insertedSessionId = repository.createSession(session);
+		session = repository.get(insertedSessionId).get();
+		session.getIdaAuthnRequestFromHub().getLevelsOfAssurance().add(AuthnContext.LEVEL_4);
+		
+		repository.updateSession(SessionId.createNewSessionId(), session);
+	}
+	
+	@Test
+	public void updateSession_shouldUpdateStoredSessionInDatabase_whenSessionExists() {
+		DateTime authnRequestIssueTime = new DateTime(2018, 4, 25, 11, 24, 0, DateTimeZone.UTC);
+		IdaAuthnRequestFromHub authnRequest = new IdaAuthnRequestFromHub("155a37d3-5a9d-4cd0-b68a-158717b85202", "test-issuer", authnRequestIssueTime, Arrays.asList(), Optional.empty(), null, null, AuthnContextComparisonTypeEnumeration.EXACT);
+		IdpSession session = createSession(authnRequest);
+		SessionId insertedSessionId = repository.createSession(session);
+		IdpSession expectedSession = repository.get(insertedSessionId).get();
+		expectedSession.getIdaAuthnRequestFromHub().getLevelsOfAssurance().add(AuthnContext.LEVEL_4);
+		repository.updateSession(insertedSessionId, expectedSession);
+		IdpSession actualSession = repository.get(insertedSessionId).get();
+		
+		assertThat(actualSession).isEqualToComparingFieldByFieldRecursively(expectedSession);
+	}
+
+	@Test
+	public void deleteSession_shouldDeleteSessionFromDatabase_whenSessionExists() {
+		DateTime authnRequestIssueTime = new DateTime(2018, 4, 25, 11, 24, 0, DateTimeZone.UTC);
+		IdaAuthnRequestFromHub authnRequest = new IdaAuthnRequestFromHub("155a37d3-5a9d-4cd0-b68a-158717b85202", "test-issuer", authnRequestIssueTime, Arrays.asList(), Optional.empty(), null, null, AuthnContextComparisonTypeEnumeration.EXACT);
+		IdpSession session = createSession(authnRequest);
+		SessionId insertedSessionId = repository.createSession(session);
+		
+		repository.deleteSession(insertedSessionId);
+		
+		assertThat(repository.containsSession(insertedSessionId)).isEqualTo(false);
+	}
+	
+	private IdpSession createSession(IdaAuthnRequestFromHub authnRequestFromHub) {
+		IdpSession session = new IdpSession(SessionId.createNewSessionId(), authnRequestFromHub, "test-relay-state", Arrays.asList(), Arrays.asList(), Optional.empty(), Optional.empty());
+		// TODO: add addresses to IdpUser below once Address has a equals() method implemented.
+		session.setIdpUser(Optional.of(new DatabaseIdpUser("jobloggs", "persistentId", "12345678", Arrays.asList(new MatchingDatasetValue<>("Joe", null, null, true)), Arrays.asList(), Arrays.asList(new MatchingDatasetValue<>("Bloggs", null, null, true)), Optional.of(new MatchingDatasetValue<>(Gender.MALE, null, null, true)), Arrays.asList(new MatchingDatasetValue<>(new LocalDate(authnRequestFromHub.getIssueInstant().getMillis(), DateTimeZone.UTC), null, null, true)), Arrays.asList(), AuthnContext.LEVEL_1)));
+		
+		return session;
+	}
+}

--- a/src/test/java/uk/gov/ida/stub/idp/resources/ConsentResourceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/resources/ConsentResourceTest.java
@@ -18,8 +18,8 @@ import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
 import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
 import uk.gov.ida.stub.idp.repositories.Idp;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.services.NonSuccessAuthnResponseService;
 import uk.gov.ida.stub.idp.services.SuccessAuthnResponseService;
@@ -47,7 +47,7 @@ public class ConsentResourceTest {
     @Mock
     private IdpStubsRepository idpStubsRepository;
     @Mock
-    private SessionRepository sessionRepository;
+    private SessionRepository<IdpSession> sessionRepository;
     @Mock
     private IdaAuthnRequestFromHub idaAuthnRequestFromHub;
     @Mock
@@ -69,7 +69,7 @@ public class ConsentResourceTest {
     public void shouldWarnUserIfLOAIsTooLow() {
         final SessionId idpSessionId = SessionId.createNewSessionId();
 
-        Session session = new Session(idpSessionId, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null);
+        IdpSession session = new IdpSession(idpSessionId, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null);
         session.setIdpUser(newUser(AuthnContext.LEVEL_1));
         when(sessionRepository.get(idpSessionId)).thenReturn(Optional.ofNullable(session));
 
@@ -86,7 +86,7 @@ public class ConsentResourceTest {
     public void shouldWarnUserIfLOAIsTooLowWhenMultipleValuesPresent() {
         final SessionId idpSessionId = SessionId.createNewSessionId();
 
-        Session session = new Session(idpSessionId, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null);
+        IdpSession session = new IdpSession(idpSessionId, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null);
         session.setIdpUser(newUser(AuthnContext.LEVEL_1));
         when(sessionRepository.get(idpSessionId)).thenReturn(Optional.ofNullable(session));
 
@@ -103,7 +103,7 @@ public class ConsentResourceTest {
     public void shouldNotWarnUserIfLOAIsOk() {
         final SessionId idpSessionId = SessionId.createNewSessionId();
 
-        Session session = new Session(idpSessionId, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null);
+        IdpSession session = new IdpSession(idpSessionId, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null);
         session.setIdpUser(newUser(AuthnContext.LEVEL_2));
         when(sessionRepository.get(idpSessionId)).thenReturn(Optional.ofNullable(session));
 

--- a/src/test/java/uk/gov/ida/stub/idp/resources/EidasConsentResourceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/resources/EidasConsentResourceTest.java
@@ -12,7 +12,7 @@ import uk.gov.ida.common.SessionId;
 import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
 import uk.gov.ida.stub.idp.domain.EidasUser;
 import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
-import uk.gov.ida.stub.idp.repositories.Session;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.repositories.StubCountry;
 import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
@@ -21,9 +21,9 @@ import uk.gov.ida.stub.idp.views.SamlResponseRedirectViewFactory;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-
 import java.util.Collections;
 import java.util.Optional;
+
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -39,10 +39,10 @@ public class EidasConsentResourceTest {
 
     private final String SCHEME_NAME = "schemeName";
     private final SessionId SESSION_ID = SessionId.createNewSessionId();
-    private Session session;
+    private EidasSession session;
 
     @Mock
-    private SessionRepository sessionRepository;
+    private SessionRepository<EidasSession> sessionRepository;
 
     @Mock
     private EidasAuthnResponseService successAuthnResponseService;
@@ -61,7 +61,7 @@ public class EidasConsentResourceTest {
         resource = new EidasConsentResource(sessionRepository, successAuthnResponseService, samlResponseRedirectViewFactory, stubCountryRepository);
 
         EidasAuthnRequest eidasAuthnRequest = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
-        session = new Session(SESSION_ID, eidasAuthnRequest, null, null, null, null, null);
+        session = new EidasSession(SESSION_ID, eidasAuthnRequest, null, null, null, null, null);
         EidasUser user = new EidasUser("Jane", "Doe", "pid", new LocalDate(1990, 1, 2), null, null);
         session.setEidasUser(user);
         when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.of(session));

--- a/src/test/java/uk/gov/ida/stub/idp/resources/EidasLoginPageResourceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/resources/EidasLoginPageResourceTest.java
@@ -13,7 +13,7 @@ import uk.gov.ida.stub.idp.Urls;
 import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
 import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
 import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
-import uk.gov.ida.stub.idp.repositories.Session;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.repositories.StubCountry;
 import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
@@ -43,15 +43,15 @@ public class EidasLoginPageResourceTest {
     }
 
     private EidasLoginPageResource resource;
-
+    private EidasSession session;
+    
     private final String SCHEME_NAME = "schemeName";
     private final SessionId SESSION_ID = SessionId.createNewSessionId();
     private final String USERNAME = "username";
     private final String PASSWORD = "password";
-    private Session session;
 
     @Mock
-    private SessionRepository sessionRepository;
+    private SessionRepository<EidasSession> sessionRepository;
 
     @Mock
 	private EidasAuthnResponseService eidasSuccessAuthnResponseService;
@@ -76,7 +76,7 @@ public class EidasLoginPageResourceTest {
         SamlResponseRedirectViewFactory samlResponseRedirectViewFactory = new SamlResponseRedirectViewFactory();
         resource = new EidasLoginPageResource(sessionRepository, eidasSuccessAuthnResponseService, samlResponseRedirectViewFactory, stubCountryRepository, stubCountryService);
         EidasAuthnRequest eidasAuthnRequest = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
-        session = new Session(SESSION_ID, eidasAuthnRequest, null, null, null, Optional.empty(), Optional.empty());
+        session = new EidasSession(SESSION_ID, eidasAuthnRequest, null, null, null, Optional.empty(), Optional.empty());
         when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(session));
         when(sessionRepository.deleteAndGet(SESSION_ID)).thenReturn(Optional.ofNullable(session), Optional.empty());
         when(eidasSuccessAuthnResponseService.generateAuthnFailed(session, SCHEME_NAME)).thenReturn(samlResponse);

--- a/src/test/java/uk/gov/ida/stub/idp/resources/LoginPageResourceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/resources/LoginPageResourceTest.java
@@ -13,8 +13,8 @@ import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
 import uk.gov.ida.stub.idp.domain.SubmitButtonValue;
 import uk.gov.ida.stub.idp.exceptions.InvalidSessionIdException;
 import uk.gov.ida.stub.idp.exceptions.InvalidUsernameOrPasswordException;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.services.IdpUserService;
 import uk.gov.ida.stub.idp.services.NonSuccessAuthnResponseService;
@@ -51,7 +51,7 @@ public class LoginPageResourceTest {
     @Mock
     private IdpStubsRepository idpStubsRepository;
     @Mock
-    private SessionRepository sessionRepository;
+    private SessionRepository<IdpSession> sessionRepository;
     @Mock
     private NonSuccessAuthnResponseService nonSuccessAuthnResponseService;
     @Mock
@@ -68,8 +68,8 @@ public class LoginPageResourceTest {
                 idpUserService,
                 sessionRepository);
 
-        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new Session(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
-        when(sessionRepository.deleteAndGet(SESSION_ID)).thenReturn(Optional.ofNullable(new Session(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
+        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new IdpSession(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
+        when(sessionRepository.deleteAndGet(SESSION_ID)).thenReturn(Optional.ofNullable(new IdpSession(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
         when(idaAuthnRequestFromHub.getId()).thenReturn(SAML_REQUEST_ID);
     }
 

--- a/src/test/java/uk/gov/ida/stub/idp/resources/RegistrationPageResourceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/resources/RegistrationPageResourceTest.java
@@ -15,8 +15,8 @@ import uk.gov.ida.stub.idp.exceptions.InvalidDateException;
 import uk.gov.ida.stub.idp.exceptions.InvalidSessionIdException;
 import uk.gov.ida.stub.idp.exceptions.InvalidUsernameOrPasswordException;
 import uk.gov.ida.stub.idp.exceptions.UsernameAlreadyTakenException;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.services.IdpUserService;
 import uk.gov.ida.stub.idp.services.NonSuccessAuthnResponseService;
@@ -58,7 +58,7 @@ public class RegistrationPageResourceTest {
     @Mock
     private NonSuccessAuthnResponseService nonSuccessAuthnResponseService;
     @Mock
-    private SessionRepository sessionRepository;
+    private SessionRepository<IdpSession> sessionRepository;
     @Mock
     private IdaAuthnRequestFromHub idaAuthnRequestFromHub;
 
@@ -72,8 +72,8 @@ public class RegistrationPageResourceTest {
                 sessionRepository
         );
 
-        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new Session(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
-        when(sessionRepository.deleteAndGet(SESSION_ID)).thenReturn(Optional.ofNullable(new Session(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
+        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new IdpSession(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
+        when(sessionRepository.deleteAndGet(SESSION_ID)).thenReturn(Optional.ofNullable(new IdpSession(SESSION_ID, idaAuthnRequestFromHub, RELAY_STATE, null, null, null, null)));
         when(idaAuthnRequestFromHub.getId()).thenReturn(SAML_REQUEST_ID);
     }
 

--- a/src/test/java/uk/gov/ida/stub/idp/services/EidasAuthnResponseServiceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/services/EidasAuthnResponseServiceTest.java
@@ -21,8 +21,8 @@ import uk.gov.ida.saml.core.extensions.eidas.PersonIdentifier;
 import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
 import uk.gov.ida.stub.idp.domain.EidasUser;
 import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
 import uk.gov.ida.stub.idp.repositories.MetadataRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
 import uk.gov.ida.stub.idp.saml.transformers.EidasResponseTransformerProvider;
 
 import java.net.URI;
@@ -63,7 +63,7 @@ public class EidasAuthnResponseServiceTest {
     @Test
     public void getEidasSuccessResponse() throws URISyntaxException, MarshallingException, SignatureException {
         EidasAuthnRequest request = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
-        Session session = new Session(new SessionId("session-id"), request, "relay-state", Collections.emptyList(), Collections.emptyList(), Optional.empty(), Optional.empty());
+        EidasSession session = new EidasSession(new SessionId("session-id"), request, "relay-state", Collections.emptyList(), Collections.emptyList(), Optional.empty(), Optional.empty());
         session.setEidasUser(new EidasUser("Firstname", "Familyname", "pid", dateOfBirth, null, null));
         when(metadataRepository.getAssertionConsumerServiceLocation()).thenReturn(new URI("http://hub.url"));
         when(eidasResponseTransformerProvider.getTransformer()).thenReturn(x -> SAML_RESPONSE_AS_STRING);
@@ -85,7 +85,7 @@ public class EidasAuthnResponseServiceTest {
     @Test
     public void getAuthnFailResponse() throws URISyntaxException {
         EidasAuthnRequest request = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
-        Session session = new Session(new SessionId("session-id"), request, "relay-state", Collections.emptyList(), Collections.emptyList(), Optional.empty(), Optional.empty());
+        EidasSession session = new EidasSession(new SessionId("session-id"), request, "relay-state", Collections.emptyList(), Collections.emptyList(), Optional.empty(), Optional.empty());
         when(metadataRepository.getAssertionConsumerServiceLocation()).thenReturn(new URI("http://hub.url"));
         when(eidasResponseTransformerProvider.getTransformer()).thenReturn(x -> SAML_RESPONSE_AS_STRING);
 

--- a/src/test/java/uk/gov/ida/stub/idp/services/IdpUserServiceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/services/IdpUserServiceTest.java
@@ -19,10 +19,11 @@ import uk.gov.ida.stub.idp.exceptions.InvalidSessionIdException;
 import uk.gov.ida.stub.idp.exceptions.InvalidUsernameOrPasswordException;
 import uk.gov.ida.stub.idp.exceptions.UsernameAlreadyTakenException;
 import uk.gov.ida.stub.idp.repositories.Idp;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
+import uk.gov.ida.stub.idp.repositories.IdpSessionRepository;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
-import uk.gov.ida.stub.idp.repositories.SessionRepository;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,7 +51,7 @@ public class IdpUserServiceTest {
     private IdpUserService idpUserService;
 
     @Mock
-    private SessionRepository sessionRepository;
+    private IdpSessionRepository sessionRepository;
     @Mock
     private Idp idp;
     @Mock
@@ -68,26 +69,26 @@ public class IdpUserServiceTest {
         when(idpStubsRepository.getIdpWithFriendlyId(IDP_NAME)).thenReturn(idp);
         Optional<DatabaseIdpUser> idpUserOptional = Optional.ofNullable(MatchingDatasetFactoryTest.completeUser);
         when(idp.getUser(USERNAME, PASSWORD)).thenReturn(idpUserOptional);
-        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new Session(SESSION_ID, idaAuthnRequestFromHubOptional, RELAY_STATE, null, null, null, null)));
+        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new IdpSession(SESSION_ID, idaAuthnRequestFromHubOptional, RELAY_STATE, null, null, null, null)));
 
         idpUserService.attachIdpUserToSession(IDP_NAME, USERNAME, PASSWORD, SESSION_ID);
 
-        ArgumentCaptor<Session> argumentCaptor = ArgumentCaptor.forClass(Session.class);
+        ArgumentCaptor<IdpSession> argumentCaptor = ArgumentCaptor.forClass(IdpSession.class);
         verify(sessionRepository, times(1)).updateSession(eq(SESSION_ID), argumentCaptor.capture());
         assertThat(argumentCaptor.getValue().getIdpUser()).isEqualTo(idpUserOptional);
     }
 
     @Test
     public void shouldHaveStatusSuccessResponseWhenUserRegisters() throws InvalidSessionIdException, IncompleteRegistrationException, InvalidDateException, UsernameAlreadyTakenException, InvalidUsernameOrPasswordException {
-        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new Session(SESSION_ID, idaAuthnRequestFromHubOptional, RELAY_STATE, null, null, null, null)));
+        IdpSession session = new IdpSession(SessionId.createNewSessionId(), idaAuthnRequestFromHubOptional, "test-relay-state", Arrays.asList(), Arrays.asList(), Optional.empty(), Optional.empty());
+        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new IdpSession(SESSION_ID, idaAuthnRequestFromHubOptional, RELAY_STATE, null, null, null, null)));
         when(idpStubsRepository.getIdpWithFriendlyId(IDP_NAME)).thenReturn(idp);
         when(idp.userExists(USERNAME)).thenReturn(false);
         when(idp.createUser(any(), any(), any(), any(), any(), any(), any(), eq(USERNAME), eq(PASSWORD), any())).thenReturn(mock(DatabaseIdpUser.class));
-        when(sessionRepository.newSession(idaAuthnRequestFromHubOptional, RELAY_STATE, null, null, null, null)).thenReturn(SESSION_ID);
+        when(sessionRepository.createSession(session)).thenReturn(SESSION_ID);
 
         idpUserService.attachIdpUserToSession(IDP_NAME, "bob", "jones", "address line 1", "address line 2", "address town", "address postcode", AuthnContext.LEVEL_2, "2000-01-01", USERNAME, "password", SESSION_ID);
 
         verify(sessionRepository, times(1)).updateSession(eq(SESSION_ID), any());
     }
-
 }

--- a/src/test/java/uk/gov/ida/stub/idp/services/NonSuccessAuthnResponseServiceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/services/NonSuccessAuthnResponseServiceTest.java
@@ -18,10 +18,7 @@ import uk.gov.ida.stub.idp.domain.FraudIndicator;
 import uk.gov.ida.stub.idp.domain.IdpIdaStatus;
 import uk.gov.ida.stub.idp.domain.OutboundResponseFromIdp;
 import uk.gov.ida.stub.idp.domain.factories.AssertionFactory;
-import uk.gov.ida.stub.idp.repositories.Idp;
-import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
-import uk.gov.ida.stub.idp.repositories.MetadataRepository;
-import uk.gov.ida.stub.idp.repositories.Session;
+import uk.gov.ida.stub.idp.repositories.*;
 import uk.gov.ida.stub.idp.saml.transformers.OutboundResponseFromIdpTransformerProvider;
 
 import java.net.URI;
@@ -128,7 +125,7 @@ public class NonSuccessAuthnResponseServiceTest {
 
     @Test
     public void shouldBuildFraudResponse(){
-        Session session = new Session(SessionId.createNewSessionId(),
+        IdpSession session = new IdpSession(SessionId.createNewSessionId(),
                 IdaAuthnRequestFromHub.createRequestReceivedFromHub(REQUEST_ID, HUB_URI.toString(), ImmutableList.of(LEVEL_2), false, DateTime.now(), AuthnContextComparisonTypeEnumeration.EXACT),
                 RELAY_STATE, null, null, null, null);
         nonSuccessAuthnResponseService.generateFraudResponse(IDP_NAME, REQUEST_ID, FraudIndicator.FI01, "ipAddress", session).getResponseString();

--- a/src/test/java/uk/gov/ida/stub/idp/services/StubCountryServiceTest.java
+++ b/src/test/java/uk/gov/ida/stub/idp/services/StubCountryServiceTest.java
@@ -15,7 +15,8 @@ import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
 import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
 import uk.gov.ida.stub.idp.exceptions.InvalidSessionIdException;
 import uk.gov.ida.stub.idp.exceptions.InvalidUsernameOrPasswordException;
-import uk.gov.ida.stub.idp.repositories.Session;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
+import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.repositories.StubCountry;
 import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
 
@@ -39,9 +40,12 @@ public class StubCountryServiceTest {
 
     private Optional<DatabaseIdpUser> user;
 
-    private Session session;
+    private EidasSession session;
 
     private EidasAuthnRequest eidasAuthnRequest;
+    
+    @Mock
+    private SessionRepository<EidasSession> sessionRepository;
 
     @Mock
     private StubCountryRepository stubCountryRepository;
@@ -52,9 +56,9 @@ public class StubCountryServiceTest {
     @Before
     public void setUp(){
         when(stubCountryRepository.getStubCountryWithFriendlyId(SCHEME_ID)).thenReturn(stubCountry);
-        stubCountryService = new StubCountryService(stubCountryRepository);
+        stubCountryService = new StubCountryService(stubCountryRepository, sessionRepository);
         eidasAuthnRequest = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
-        session = new Session(SESSION_ID, eidasAuthnRequest, null, null, null, Optional.empty(), Optional.empty());
+        session = new EidasSession(SESSION_ID, eidasAuthnRequest, null, null, null, Optional.empty(), Optional.empty());
         user = newUser();
     }
 


### PR DESCRIPTION
Currently Stub IdP stores all session data in an in-memory cache. When the application stops as part of a deployment, all session data currently in-memory is lost, meaning that anyone using the Stub IdP at this time will need to restart their entire Verify journey.

This PR refactors the Stub IdP to be able to serialize/deserialize session data to and from an external data store. It is intended as a solution to tackle the immediate issue of zero-downtime deploys of Stub IdP; refactoring the stored session data to remove unnecessary dependencies may help to remove some of the brittleness around serialization and deserialization, especially of external types, is a piece of work that will come later on.

Co-authored-by: Rosa Fox <rosa.fox@digital.cabinet-office.gov.uk>