### PR TITLE
BAU: Clean up smoke test containers

### DIFF
--- a/smoke-test/run-smoke-test.sh
+++ b/smoke-test/run-smoke-test.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 set -eu
 
+trap 'docker-compose down' EXIT
+
 docker-compose up -d selenium-hub
 docker-compose build smoke-tester
 docker-compose run \
@@ -10,5 +12,3 @@ docker-compose run \
                -e IDP_PASSWORD=$IDP_PASSWORD \
                smoke-tester \
                paas_smoke_test.rb
-docker-compose down
-


### PR DESCRIPTION
set -e was causing script to exit before docker-compose
down was executed. Add 'down' to trap to ensure containers
are always cleaned up