### PR TITLE
EID-673: Add users with non-ASCII names for testing purposes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ apply plugin: 'maven-publish'
 
 mainClassName = 'uk.gov.ida.stub.idp.StubIdpApplication'
 
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
 
 archivesBaseName = 'stub-idp'
 

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/HardCodedTestUserList.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/HardCodedTestUserList.java
@@ -187,9 +187,9 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 createMdsValue("Jack"),
-                Optional.of(createMdsValue("JackNonLatin")),
+                Optional.empty(),
                 createMdsValue("Bauer"),
-                Optional.of(createMdsValue("BauerNonLatin")),
+                Optional.empty(),
                 createMdsValue(LocalDate.parse("1984-02-29")),
                 AuthnContext.LEVEL_2));
 
@@ -198,9 +198,9 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 createMdsValue("Martin"),
-                Optional.of(createMdsValue("MartinNonLatin")),
+                Optional.empty(),
                 createMdsValue("McFly"),
-                Optional.of(createMdsValue("McFlyNonLatin")),
+                Optional.empty(),
                 createMdsValue(LocalDate.parse("1968-06-12")),
                 AuthnContext.LEVEL_2));
 
@@ -210,9 +210,9 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 createMdsValue("Jack"),
-                Optional.of(createMdsValue("JackNonLatin")),
+                Optional.empty(),
                 createMdsValue("Griffin"),
-                Optional.of(createMdsValue("GriffinNonLatin")),
+                Optional.empty(),
                 createMdsValue(LocalDate.parse("1983-06-21")),
                 AuthnContext.LEVEL_2));
 
@@ -220,9 +220,9 @@ public final class HardCodedTestUserList {
                 idpFriendlyId + "-c3",
                 UUID.randomUUID().toString(), "bar",
                 createMdsValue("J"),
-                Optional.of(createMdsValue("JNonLatin")),
+                Optional.empty(),
                 createMdsValue("Surname"),
-                Optional.of(createMdsValue("SurnameNonLatin")),
+                Optional.empty(),
                 createMdsValue(LocalDate.parse("1822-11-27")),
                 AuthnContext.LEVEL_2));
 
@@ -231,9 +231,9 @@ public final class HardCodedTestUserList {
                  UUID.randomUUID().toString(),
                 "bar",
                 createMdsValue("Martin"),
-                Optional.of(createMdsValue("MartinNonLatin")),
+                Optional.empty(),
                 createMdsValue("Riggs"),
-                Optional.of(createMdsValue("RiggsNonLatin")),
+                Optional.empty(),
                 createMdsValue(LocalDate.parse("1970-04-12")),
                 AuthnContext.LEVEL_2));
 
@@ -242,9 +242,9 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 new MatchingDatasetValue<>("Jack", DateTime.now(), DateTime.now(), true),
-                Optional.of(new MatchingDatasetValue<>("JackNonLatin", DateTime.now(), DateTime.now(), true)),
+                Optional.empty(),
                 new MatchingDatasetValue<>("Bauer", DateTime.now(), DateTime.now(), true),
-                Optional.of(new MatchingDatasetValue<>("BauerNonLatin", DateTime.now(), DateTime.now(), true)),
+                Optional.empty(),
                 new MatchingDatasetValue<>(LocalDate.parse("1984-02-29"), DateTime.now(), DateTime.now(), true),
                 AuthnContext.LEVEL_2));
 
@@ -253,9 +253,9 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 new MatchingDatasetValue<>("Jessica", DateTime.now(), null, false),
-                Optional.of(new MatchingDatasetValue<>("JessicaNonLatin", DateTime.now(), null, false)),
+                Optional.empty(),
                 new MatchingDatasetValue<>("Rabbit", DateTime.now(), null, false),
-                Optional.of(new MatchingDatasetValue<>("RabbitNonLatin", DateTime.now(), null, false)),
+                Optional.empty(),
                 new MatchingDatasetValue<>(LocalDate.parse("1960-03-23"), DateTime.now(), null, false),
                 AuthnContext.LEVEL_1));
 
@@ -264,9 +264,9 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 new MatchingDatasetValue<>("Roger", DateTime.now(), DateTime.now(), true),
-                Optional.of(new MatchingDatasetValue<>("RogerNonLatin", DateTime.now(), DateTime.now(), true)),
+                Optional.empty(),
                 new MatchingDatasetValue<>("Rabbit", DateTime.now(), DateTime.now(), true),
-                Optional.of(new MatchingDatasetValue<>("RabbitNonLatin", DateTime.now(), DateTime.now(), true)),
+                Optional.empty(),
                 new MatchingDatasetValue<>(LocalDate.parse("1958-04-09"), DateTime.now(), DateTime.now(), true),
                 AuthnContext.LEVEL_2));
 
@@ -275,8 +275,9 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 new MatchingDatasetValue<>("Apollo", DateTime.now(), null, true),
-                Optional.of(new MatchingDatasetValue<>("ApolloNonLatin", DateTime.now(), null, true)),
-                new MatchingDatasetValue<>("Eagle", DateTime.now(), null, true), Optional.of(new MatchingDatasetValue<>("EagleNonLatin", DateTime.now(), null, true)),
+                Optional.empty(),
+                new MatchingDatasetValue<>("Eagle", DateTime.now(), null, true),
+                Optional.empty(),
                 new MatchingDatasetValue<>(LocalDate.parse("1969-07-20"), DateTime.now(), null, true),
                 AuthnContext.LEVEL_3));
 
@@ -285,19 +286,19 @@ public final class HardCodedTestUserList {
                 UUID.randomUUID().toString(),
                 "bar",
                 new MatchingDatasetValue<>("Bugs", DateTime.now(), DateTime.now(), true),
-                Optional.of(new MatchingDatasetValue<>("BugsNonLatin", DateTime.now(), DateTime.now(), true)),
+                Optional.empty(),
                 new MatchingDatasetValue<>("Nummy", DateTime.now(), DateTime.now(), true),
-                Optional.of(new MatchingDatasetValue<>("NummyNonLatin", DateTime.now(), DateTime.now(), true)),
+                Optional.empty(),
                 new MatchingDatasetValue<>(LocalDate.parse("1958-04-09"), DateTime.now(), DateTime.now(), true),
                 AuthnContext.LEVEL_X));
 
         sacredUsers.add(new DatabaseEidasUser(idpFriendlyId + "-emoji",
                 UUID.randomUUID().toString(),
                 "bar",
-                createMdsValue("😀"),
-                Optional.of(createMdsValue("😀NonLatin")),
-                createMdsValue("🙃"),
-                Optional.of(createMdsValue("🙃NonLatin")),
+                createMdsValue("GRINNING FACE"),
+                Optional.of(createMdsValue("😀")),
+                createMdsValue("UPSIDE-DOWN FACE"),
+                Optional.of(createMdsValue("🙃")),
                 createMdsValue(LocalDate.parse("1968-06-12")),
                 AuthnContext.LEVEL_2));
 

--- a/src/main/java/uk/gov/ida/stub/idp/repositories/HardCodedTestUserList.java
+++ b/src/main/java/uk/gov/ida/stub/idp/repositories/HardCodedTestUserList.java
@@ -204,6 +204,28 @@ public final class HardCodedTestUserList {
                 createMdsValue(LocalDate.parse("1968-06-12")),
                 AuthnContext.LEVEL_2));
 
+        // These names contain characters from ISO/IEC 8859-15 which we regard as Latin.
+        sacredUsers.add(new DatabaseEidasUser(
+                idpFriendlyId + "-accents",
+                UUID.randomUUID().toString(),
+                "bar",
+                createMdsValue("Šarlota"),
+                Optional.empty(),
+                createMdsValue("Snježana"),
+                Optional.empty(),
+                createMdsValue(LocalDate.parse("1978-06-12")),
+                AuthnContext.LEVEL_2));
+
+        sacredUsers.add(new DatabaseEidasUser(
+                idpFriendlyId + "-nonlatin",
+                UUID.randomUUID().toString(),
+                "bar",
+                createMdsValue("Georgios"),
+                Optional.of(createMdsValue("Γεώργιος")),
+                createMdsValue("Panathinaikos"),
+                Optional.of(createMdsValue("Παναθηναϊκός")),
+                createMdsValue(LocalDate.parse("1967-06-12")),
+                AuthnContext.LEVEL_2));
 
         sacredUsers.add(new DatabaseEidasUser(
                 idpFriendlyId + "-new",


### PR DESCRIPTION
There is a seperate commit in verify-acceptance-tests for make use of these.