### PR TITLE
Bau - Point at the actual main class location

### DIFF
--- a/stub-idp/build.gradle
+++ b/stub-idp/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 apply plugin: 'application'
 apply plugin: 'maven-publish'
 
-mainClassName = 'uk.gov.ida.hub.stub.idp.StubIdpApplication'
+mainClassName = 'uk.gov.ida.stub.idp.StubIdpApplication'
 
 task paasManifestFileCheck {
     doFirst {


### PR DESCRIPTION
-This was causing failures when starting up, with hub-startup.sh
due to the main class not being found.
-Change to point where the main class is located