### PR TITLE
Bau - Minor fix to allow import into intellij

### DIFF
--- a/inttest.gradle
+++ b/inttest.gradle
@@ -11,10 +11,10 @@ idea {
 sourceSets {
     integrationTest {
         java {
-            srcDir 'src/integration-test/java'
+            srcDir "${rootDir}/src/integration-test/java"
         }
         resources {
-            srcDir 'src/integration-test/resources'
+            srcDir "${rootDir}/src/integration-test/resources"
             srcDir "${rootDir}/configuration"
         }
         compileClasspath += sourceSets.main.runtimeClasspath

--- a/stub-idp/build.gradle
+++ b/stub-idp/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 
 apply plugin: 'application'
 apply plugin: 'maven-publish'
+apply plugin: 'idea'
 
 mainClassName = 'uk.gov.ida.stub.idp.StubIdpApplication'
 


### PR DESCRIPTION
- IntelliJ was complaining when importing the project into intellij, this is likely to be due to the recent project structure change. All repos now sit as children, therefore the first change to inttest.gradle is to ensure it looks in the right location. It also seemed to need the "idea" gradle plugin for the build.gradle in stub-idp. 