### PR TITLE
BAU: Fix stub-idp path in services.yaml

### DIFF
--- a/bin/services.yaml
+++ b/bin/services.yaml
@@ -1,3 +1,3 @@
 ---
 stub-idp:
-  path: ../verify-stub-idp
+  path: stub-idp


### PR DESCRIPTION
The `services.yaml` file defines the paths to subprojects used by
`bin/build.rb`. Update path since stub-idp has been moved to a subproject in this
repo.