### PR TITLE
EID-835 - Sign stub country assertions using RSASSA-PSS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,6 @@ apply plugin: 'idea'
 apply plugin: 'java'
 apply plugin: 'com.github.ben-manes.versions'
 
-compileJava.options.encoding = "UTF-8"
-compileTestJava.options.encoding = "UTF-8"
-
 ext {
   opensaml_version = '3.3.0'
   build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
@@ -31,7 +28,7 @@ def dependencyVersions = [
         ida_utils             : '2.0.0-336',
         dropwizard            : '1.1.4',
         ida_dev_pki           : '1.1.0-34',
-        saml_libs             : "$opensaml_version-147",
+        saml_libs             : "$opensaml_version-156",
         ida_test_utils        : '2.0.0-43',
         hub_saml              : "$opensaml_version-15582",
         hk2_version           : '2.5.0-b05'
@@ -42,6 +39,9 @@ subprojects {
 
     group = "uk.gov.ida"
     version = "${version ?: 'SNAPSHOT'}"
+
+    compileJava.options.encoding = "UTF-8"
+    compileTestJava.options.encoding = "UTF-8"
 
     repositories {
         if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {

--- a/stub-idp/src/integration-test/java/uk/gov/ida/apprule/support/SamlDecrypter.java
+++ b/stub-idp/src/integration-test/java/uk/gov/ida/apprule/support/SamlDecrypter.java
@@ -157,7 +157,9 @@ public class SamlDecrypter {
         IdaKeyStoreCredentialRetriever idaKeyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(keyStore);
         Decrypter decrypter = new DecrypterFactory().createDecrypter(idaKeyStoreCredentialRetriever.getDecryptingCredentials());
         return new AssertionDecrypter(
-                new EncryptionAlgorithmValidator(ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256, EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM)),
+                new EncryptionAlgorithmValidator(
+                    ImmutableSet.of(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256, EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM),
+                    ImmutableSet.of(EncryptionConstants.ALGO_ID_KEYTRANSPORT_RSAOAEP)),
                 decrypter
         );
     }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -43,6 +43,7 @@ import uk.gov.ida.saml.security.IdaKeyStore;
 import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
 import uk.gov.ida.saml.security.SignatureFactory;
 import uk.gov.ida.saml.security.SigningKeyStore;
+import uk.gov.ida.saml.security.signature.SignatureRSASSAPSS;
 import uk.gov.ida.stub.idp.auth.ManagedAuthFilterInstaller;
 import uk.gov.ida.stub.idp.builders.CountryMetadataBuilder;
 import uk.gov.ida.stub.idp.builders.CountryMetadataSigningHelper;
@@ -315,7 +316,7 @@ public class StubIdpModule extends AbstractModule {
             encryptionKeyStore.orElse(null),
             keyStore,
             entityToEncryptForLocator,
-            new SignatureRSASHA256(),
+            new SignatureRSASSAPSS(),
             new DigestSHA256()
         );
     }


### PR DESCRIPTION
- eIDAS assertions should only be signed using either RSASSA-PSS or ECDSA. This
change will ensure that eidas assertions are signed using RSASSA-PSS.
- However as our private keys are RSA, to sign with ECDSA would require a different private key.
Which would require a significant amount of work. We are aware that some proxy nodes use ECDSA,
which will allow us to test this in integration.
- The MSA will need to be [upgraded and released](https://github.com/alphagov/verify-matching-service-adapter/pull/91) before this is release so it can support the required algorithms.