### PR TITLE
Bau - Rollback stub country signing algorithm

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -316,7 +316,7 @@ public class StubIdpModule extends AbstractModule {
             encryptionKeyStore.orElse(null),
             keyStore,
             entityToEncryptForLocator,
-            new SignatureRSASSAPSS(),
+            new SignatureRSASHA256(),
             new DigestSHA256()
         );
     }


### PR DESCRIPTION
- There are MSA's on integration that haven't yet upgraded so are failing
because this algorithm for stub country isn't yet supported.
- Rolling back to the previous signing algorithm until we decide
how best to test with the new one