### PR TITLE
EID-894 - Give stub country the ability to support other signing algorithms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,10 @@ ext {
 
 def dependencyVersions = [
         opensaml              : "$opensaml_version",
-        ida_utils             : '2.0.0-336',
+        ida_utils             : '2.0.0-340',
         dropwizard            : '1.1.4',
         ida_dev_pki           : '1.1.0-34',
-        saml_libs             : "$opensaml_version-156",
+        saml_libs             : "$opensaml_version-157",
         ida_test_utils        : '2.0.0-43',
         hub_saml              : "$opensaml_version-15582",
         hk2_version           : '2.5.0-b05'

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -154,7 +154,6 @@ public class StubIdpModule extends AbstractModule {
 
         bind(AuthnRequestReceiverService.class);
         bind(SuccessAuthnResponseService.class);
-        bind(EidasAuthnResponseService.class);
         bind(GeneratePasswordService.class);
         bind(NonSuccessAuthnResponseService.class);
         bind(IdpUserService.class);
@@ -307,6 +306,51 @@ public class StubIdpModule extends AbstractModule {
     }
 
     @Provides
+    @Named("RSASHA256EidasAuthnResponseService")
+    public EidasAuthnResponseService getECDSAEidasAuthnResponseService(
+       @Named("HubConnectorEntityId") String hubConnectorEntityId,
+       @Named("RSASHA256EidasResponseTransfomerProvider") EidasResponseTransformerProvider eidasResponseTransformerProvider,
+       @Named(StubIdpModule.HUB_CONNECTOR_METADATA_REPOSITORY) Optional<MetadataRepository> metadataProvider,
+       @Named("StubCountryMetadataUrl") String stubCountryMetadataUrl) {
+        return new EidasAuthnResponseService(
+                hubConnectorEntityId,
+                eidasResponseTransformerProvider,
+                metadataProvider,
+                stubCountryMetadataUrl);
+    }
+
+    @Provides
+    @Named("RSASHA256EidasResponseTransfomerProvider")
+    public EidasResponseTransformerProvider getECDSAEidasResponseTransfomerProvider(
+            @Named(StubIdpModule.HUB_CONNECTOR_ENCRYPTION_KEY_STORE) Optional<EncryptionKeyStore> encryptionKeyStore,
+            @Named(COUNTRY_SIGNING_KEY_STORE) IdaKeyStore keyStore,
+            EntityToEncryptForLocator entityToEncryptForLocator) {
+        return new EidasResponseTransformerProvider(
+                new CoreTransformersFactory(),
+                encryptionKeyStore.orElse(null),
+                keyStore,
+                entityToEncryptForLocator,
+                new SignatureRSASHA256(),
+                new DigestSHA256()
+        );
+    }
+
+    @Provides
+    @Named("RSASSAPSSEidasAuthnResponseService")
+    public EidasAuthnResponseService getRSASSAPSSEidasAuthnResponseService(
+            @Named("HubConnectorEntityId") String hubConnectorEntityId,
+            @Named("RSASSAPSSEidasResponseTransformerProvider") EidasResponseTransformerProvider eidasResponseTransformerProvider,
+            @Named(StubIdpModule.HUB_CONNECTOR_METADATA_REPOSITORY) Optional<MetadataRepository> metadataProvider,
+            @Named("StubCountryMetadataUrl") String stubCountryMetadataUrl) {
+        return new EidasAuthnResponseService(
+                hubConnectorEntityId,
+                eidasResponseTransformerProvider,
+                metadataProvider,
+                stubCountryMetadataUrl);
+    }
+
+    @Named("RSASSAPSSEidasResponseTransformerProvider")
+    @Provides
     public EidasResponseTransformerProvider getEidasResponseTransformerProvider(
         @Named(StubIdpModule.HUB_CONNECTOR_ENCRYPTION_KEY_STORE) Optional<EncryptionKeyStore> encryptionKeyStore,
         @Named(COUNTRY_SIGNING_KEY_STORE) IdaKeyStore keyStore,
@@ -316,7 +360,7 @@ public class StubIdpModule extends AbstractModule {
             encryptionKeyStore.orElse(null),
             keyStore,
             entityToEncryptForLocator,
-            new SignatureRSASHA256(),
+            new SignatureRSASSAPSS(),
             new DigestSHA256()
         );
     }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/Urls.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/Urls.java
@@ -32,6 +32,7 @@ public interface Urls {
     String RANDOMISE_PID_PARAM = "randomPid";
     String CYCLE3_PARAM = "c3";
     String LEVEL_OF_ASSURANCE_PARAM = "loa";
+    String SIGNING_ALGORITHM_PARAM = "signingAlgorithm";
 
     // paths and resources
     String IDP_SAML2_SSO_RESOURCE = "/{"+IDP_ID_PARAM+"}/SAML2/SSO";

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/exceptions/InvalidSigningAlgorithmException.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/exceptions/InvalidSigningAlgorithmException.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.stub.idp.exceptions;
+
+public class InvalidSigningAlgorithmException extends RuntimeException {
+
+    public InvalidSigningAlgorithmException(String signingAlgorithm) {
+        super("Invalid Signing Algorithm " + signingAlgorithm);
+    }
+}

--- a/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/eidasConsent.ftl
+++ b/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/eidasConsent.ftl
@@ -40,9 +40,11 @@
         <p>Do you agree to allow ${name} to send your personal details to the relying party from which you are
             authenticating?</p>
     </div>
-    <div class="submit">
-        <form action="/eidas/${idpId}/consent" method="post">
-            <input id="agree" class="button color-ok" type="submit" name="submit" value="I Agree"/>
-        </form>
-    </div>
+     <form action="/eidas/${idpId}/consent" method="post">
+         <p class="submit">
+             <input id="agree" class="button color-ok" type="submit" name="submit" value="I Agree"/>
+         </p>
+          <!-- this is used by acceptance tests -->
+          <input id="signingAlgorithm" name="signingAlgorithm" type="hidden" value="rsasha256"/>
+     </form>
 </div>

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasConsentResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasConsentResourceTest.java
@@ -13,6 +13,8 @@ import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
 import uk.gov.ida.stub.idp.domain.EidasScheme;
 import uk.gov.ida.stub.idp.domain.EidasUser;
 import uk.gov.ida.stub.idp.domain.SamlResponseFromValue;
+import uk.gov.ida.stub.idp.exceptions.InvalidSigningAlgorithmException;
+import uk.gov.ida.stub.idp.exceptions.InvalidUsernameOrPasswordException;
 import uk.gov.ida.stub.idp.repositories.EidasSession;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 import uk.gov.ida.stub.idp.repositories.StubCountry;
@@ -60,7 +62,7 @@ public class EidasConsentResourceTest {
 
     @Before
     public void setUp(){
-        resource = new EidasConsentResource(sessionRepository, successAuthnResponseService, samlResponseRedirectViewFactory, stubCountryRepository);
+        resource = new EidasConsentResource(sessionRepository, successAuthnResponseService, successAuthnResponseService, samlResponseRedirectViewFactory, stubCountryRepository);
 
         EidasAuthnRequest eidasAuthnRequest = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
         session = new EidasSession(SESSION_ID, eidasAuthnRequest, null, null, null, null, null);
@@ -80,15 +82,36 @@ public class EidasConsentResourceTest {
     }
 
     @Test
-    public void postShouldReturnASuccessfulResponseWhenSessionIsValid() {
+    public void postShouldReturnASuccessfulResponseWithRsaSha256SigningAlgorithmWhenSessionIsValid() {
         SamlResponseFromValue<org.opensaml.saml.saml2.core.Response> samlResponse = new SamlResponseFromValue<org.opensaml.saml.saml2.core.Response>(null, (r) -> null, null, null);
         when(successAuthnResponseService.getSuccessResponse(session, SCHEME_NAME)).thenReturn(samlResponse);
         when(samlResponseRedirectViewFactory.sendSamlMessage(samlResponse)).thenReturn(Response.ok().build());
 
-        final Response response = resource.consent(SCHEME_NAME, "submit", SESSION_ID);
+        final Response response = resource.consent(SCHEME_NAME, "rsasha256","submit", SESSION_ID);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
+
+    @Test
+    public void postShouldReturnASuccessfulResponseWithRsaSsaPsaSigningAlgorithmWhenSessionIsValid() {
+        SamlResponseFromValue<org.opensaml.saml.saml2.core.Response> samlResponse = new SamlResponseFromValue<org.opensaml.saml.saml2.core.Response>(null, (r) -> null, null, null);
+        when(successAuthnResponseService.getSuccessResponse(session, SCHEME_NAME)).thenReturn(samlResponse);
+        when(samlResponseRedirectViewFactory.sendSamlMessage(samlResponse)).thenReturn(Response.ok().build());
+
+        final Response response = resource.consent(SCHEME_NAME, "rsassa-pss","submit", SESSION_ID);
+
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
+
+    @Test(expected = InvalidSigningAlgorithmException.class)
+    public void postShouldThrowAnExceptionWhenAnInvalidSigningAlgorithmIsUsed() {
+        SamlResponseFromValue<org.opensaml.saml.saml2.core.Response> samlResponse = new SamlResponseFromValue<org.opensaml.saml.saml2.core.Response>(null, (r) -> null, null, null);
+        when(successAuthnResponseService.getSuccessResponse(session, SCHEME_NAME)).thenReturn(samlResponse);
+        when(samlResponseRedirectViewFactory.sendSamlMessage(samlResponse)).thenReturn(Response.ok().build());
+
+        resource.consent(SCHEME_NAME, "rsa-sha384","submit", SESSION_ID);
+    }
+
 
     @Test(expected = WebApplicationException.class)
     public void shouldThrowAWebApplicationExceptionWhenSessionIsEmpty(){


### PR DESCRIPTION
- By default Stub Country's response is signed with rsasha256, however this
change will allow stub country to sign assertions with the rsassa-pss signing algorithm through
the acceptance tests. This is to ensure that the MSA can support responses with the rsassa-pss signing algorithm as per the eidas crypto spec. 
- The acceptance test will overwrite the value in eidasConsent.ftl with the rsassa-pss algorithm and perform a journey using stub-country. 
- Upgraded to latest version of ida_utils and saml_libs.  