### PR TITLE
EID-921 - Add validation to check X509 in EidasAuthnRequest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
 
 def dependencyVersions = [
         opensaml              : "$opensaml_version",
-        ida_utils             : '2.0.0-340',
+        ida_utils             : '2.0.0-343',
         dropwizard            : '1.1.4',
         ida_dev_pki           : '1.1.0-34',
         saml_libs             : "$opensaml_version-157",

--- a/stub-idp/src/integration-test/java/uk/gov/ida/apprule/EidasCountryMetadataIntegrationTests.java
+++ b/stub-idp/src/integration-test/java/uk/gov/ida/apprule/EidasCountryMetadataIntegrationTests.java
@@ -8,15 +8,12 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 import uk.gov.ida.apprule.support.IntegrationTestHelper;
 import uk.gov.ida.apprule.support.StubIdpAppRule;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.stub.idp.builders.StubIdpBuilder.aStubIdp;
@@ -40,7 +37,7 @@ public class EidasCountryMetadataIntegrationTests extends IntegrationTestHelper 
     }
 
     @Test
-    public void countryMetadataShouldContainCorrectEntityIdAndSsoUrl() throws ParserConfigurationException, IOException, SAXException {
+    public void countryMetadataShouldContainCorrectEntityIdAndSsoUrl() {
         String baseUrl = applicationRule.getConfiguration().getEuropeanIdentityConfiguration().getStubCountryBaseUrl();
         String metadataEndpoint = baseUrl + "/stub-country/ServiceMetadata";
         String expectedSsoUrl = baseUrl + "/eidas/stub-country/SAML2/SSO";

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/exceptions/InvalidEidasAuthnRequestException.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/exceptions/InvalidEidasAuthnRequestException.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.stub.idp.exceptions;
+
+public class InvalidEidasAuthnRequestException extends RuntimeException {
+
+    public InvalidEidasAuthnRequestException(String messsage) {
+        super("Invalid Eidas Authn Request: " + messsage);
+    }
+}

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/domain/EidasAuthnRequestTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/domain/EidasAuthnRequestTest.java
@@ -1,7 +1,12 @@
 package uk.gov.ida.stub.idp.domain;
 
+import com.squarespace.jersey2.guice.JerseyGuiceUtils;
+import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AuthnContextClassRef;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -9,6 +14,12 @@ import org.opensaml.saml.saml2.core.Extensions;
 import org.opensaml.saml.saml2.core.RequestedAuthnContext;
 import org.opensaml.saml.saml2.core.impl.ExtensionsBuilder;
 import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder;
+import org.opensaml.xmlsec.algorithm.descriptors.DigestSHA256;
+import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
+import org.opensaml.xmlsec.signature.Signature;
+import uk.gov.ida.common.shared.security.PrivateKeyFactory;
+import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.saml.core.IdaConstants;
 import uk.gov.ida.saml.core.IdaSamlBootstrap;
 import uk.gov.ida.saml.core.extensions.RequestedAttribute;
@@ -17,23 +28,74 @@ import uk.gov.ida.saml.core.extensions.impl.RequestedAttributeBuilder;
 import uk.gov.ida.saml.core.extensions.impl.RequestedAttributesBuilder;
 import uk.gov.ida.saml.core.extensions.impl.RequestedAttributesImpl;
 import uk.gov.ida.saml.core.extensions.impl.SPTypeBuilder;
+import uk.gov.ida.saml.core.test.OpenSAMLMockitoRunner;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+import uk.gov.ida.saml.core.test.TestEntityIds;
 import uk.gov.ida.saml.core.test.builders.AuthnContextClassRefBuilder;
 import uk.gov.ida.saml.core.test.builders.AuthnRequestBuilder;
 import uk.gov.ida.saml.core.test.builders.IssuerBuilder;
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.saml.hub.domain.LevelOfAssurance;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+import uk.gov.ida.saml.security.SignatureWithKeyInfoFactory;
+import uk.gov.ida.stub.idp.exceptions.InvalidEidasAuthnRequestException;
+import uk.gov.ida.stub.idp.repositories.EidasSessionRepository;
+import uk.gov.ida.stub.idp.repositories.IdpSessionRepository;
+import uk.gov.ida.stub.idp.services.AuthnRequestReceiverService;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
 
+@RunWith(OpenSAMLMockitoRunner.class)
 public class EidasAuthnRequestTest {
+
+    @BeforeClass
+    public static void doALittleHackToMakeGuicierHappyForSomeReason() {
+        JerseyGuiceUtils.reset();
+    }
+
+    private static final String SCHEME_ID = "schemeId";
+
+    private static final String SAML_REQUEST = "samlRequest";
+
+    private static final String RELAY_STATE = "relayState";
+
+    private AuthnRequestReceiverService authnRequestReceiverService;
+
+    private AuthnRequest authnRequest;
+
+    @Mock
+    private Function<String, IdaAuthnRequestFromHub> samlRequestTransformer;
+
+    @Mock
+    private IdpSessionRepository idpSessionRepository;
+
+    @Mock
+    private EidasSessionRepository eidasSessionRepository;
+
+    @Mock
+    private Function<String, AuthnRequest> stringAuthnRequestTransformer;
 
     @Before
     public void setUp(){
         IdaSamlBootstrap.bootstrap();
+        authnRequestReceiverService = new AuthnRequestReceiverService(
+                samlRequestTransformer, idpSessionRepository, eidasSessionRepository, stringAuthnRequestTransformer);
+        authnRequest = AuthnRequestBuilder.anAuthnRequest().build();
     }
 
     @Test
     public void shouldConvertAuthnRequestToEidasAuthnRequest() {
-        AuthnRequest authnRequest = AuthnRequestBuilder.anAuthnRequest()
+        authnRequest = AuthnRequestBuilder.anAuthnRequest()
                 .withIssuer(
                         IssuerBuilder.anIssuer().withIssuerId("issuer-id").build()
                 )
@@ -65,7 +127,56 @@ public class EidasAuthnRequestTest {
         assertThat(requestedAttribute.isRequired()).isEqualTo(true);
     }
 
-    // this code is copied from EidasAuthnRequestBuilder
+    @Test(expected = InvalidEidasAuthnRequestException.class)
+    public void shouldThrowWhenAuthnRequestDoesntContainKeyInfo() {
+        when(stringAuthnRequestTransformer.apply(any())).thenReturn(authnRequest);
+        authnRequestReceiverService.handleEidasAuthnRequest(SCHEME_ID, SAML_REQUEST, RELAY_STATE, Optional.empty());
+    }
+
+    @Test(expected = InvalidEidasAuthnRequestException.class)
+    public void shouldThrowWhenAuthnRequestDoesntContainX509Data() {
+        authnRequest.setSignature(createSignatureWithKeyInfo());
+        authnRequest.getSignature().getKeyInfo().getX509Datas().clear();
+
+        when(stringAuthnRequestTransformer.apply(any())).thenReturn(authnRequest);
+
+        authnRequestReceiverService.handleEidasAuthnRequest(SCHEME_ID, SAML_REQUEST, RELAY_STATE, Optional.empty());
+    }
+
+    @Test(expected = InvalidEidasAuthnRequestException.class)
+    public void shouldThrowWhenAuthnRequestDoesntContainAnyX509Certs() {
+        authnRequest.setSignature(createSignatureWithKeyInfo());
+        authnRequest.getSignature().getKeyInfo().getX509Datas().get(0).getX509Certificates().clear();
+
+        when(stringAuthnRequestTransformer.apply(any())).thenReturn(authnRequest);
+
+        authnRequestReceiverService.handleEidasAuthnRequest(SCHEME_ID, SAML_REQUEST, RELAY_STATE, Optional.empty());
+    }
+
+    private Signature createSignatureWithKeyInfo() {
+        IdaKeyStoreCredentialRetriever keyStoreCredentialRetriever = new IdaKeyStoreCredentialRetriever(createIdaKeyStore());
+
+        SignatureWithKeyInfoFactory keyInfoFactory = new SignatureWithKeyInfoFactory(keyStoreCredentialRetriever,new SignatureRSASHA256(), new DigestSHA256(), "issue-id","signing-cert");
+
+        return keyInfoFactory.createSignature();
+    }
+
+    private IdaKeyStore createIdaKeyStore() {
+        PublicKeyFactory publicKeyFactory = new PublicKeyFactory(new X509CertificateFactory());
+
+        PrivateKey privateSigningKey = new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(TestCertificateStrings.PRIVATE_SIGNING_KEYS.get(
+                TestEntityIds.HUB_ENTITY_ID)));
+        PublicKey publicSigningKey = publicKeyFactory.createPublicKey(TestCertificateStrings.getPrimaryPublicEncryptionCert(TestEntityIds.HUB_ENTITY_ID));
+
+        PrivateKey publicEncryptionKey = new PrivateKeyFactory().createPrivateKey(Base64.decodeBase64(TestCertificateStrings.HUB_TEST_PRIVATE_ENCRYPTION_KEY));;
+        PublicKey privateEncryptionKey = publicKeyFactory.createPublicKey(TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT);
+
+        KeyPair signingKeyPair = new KeyPair(publicSigningKey, privateSigningKey);
+        KeyPair encryptionKeyPair = new KeyPair(privateEncryptionKey, publicEncryptionKey);
+
+        return new IdaKeyStore(signingKeyPair, Arrays.asList(encryptionKeyPair));
+    }
+
     private Extensions createEidasExtensions() {
         SPType spType = new SPTypeBuilder().buildObject();
         spType.setValue("public");
@@ -86,5 +197,4 @@ public class EidasAuthnRequestTest {
         attr.setIsRequired(true);
         return attr;
     }
-
 }


### PR DESCRIPTION
- Countries validate that KeyInfo and X509 certs exist in the EidasAuthnRequest,
so we should ensure StubCountry also validates this.
- Add new exception when EidasAuthnRequest is invalid
- Update ida_utils version to the latest 
- Add tests to check exception is thrown with EidasAuthnRequest does not contain x509 or key info 
