### PR TITLE
HUB-271: Changed url string in test to reflect correct endpoint

### DIFF
--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/ServiceListServiceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/ServiceListServiceTest.java
@@ -31,7 +31,7 @@ public class ServiceListServiceTest {
     private final Service service4 = new Service("Service Description 4", "LEVEL_2", "service-description-4-entity-id", "Service Category B");
     private final Service service5 = new Service("Service Description 5", "LEVEL_1", "service-description-5-entity-id", "Service Category B");
 
-    private final URI uri = URI.create("http://localhost/get-service-list");
+    private final URI uri = URI.create("http://localhost/get-available-services");
 
     @Mock
     private SingleIdpConfiguration singleIdpConfiguration;


### PR DESCRIPTION
Small change to make test string match correct url in frontend rather
than hub to save potential confusion.

solo: @rachelthecodesmith