### PR TITLE
add a stale session reaper to remove stale sessions from the db

### DIFF
--- a/stub-idp/src/integration-test/java/uk/gov/ida/apprule/UserLogsInIntegrationTests.java
+++ b/stub-idp/src/integration-test/java/uk/gov/ida/apprule/UserLogsInIntegrationTests.java
@@ -5,6 +5,7 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.ida.apprule.steps.AuthnRequestSteps;
 import uk.gov.ida.apprule.support.IntegrationTestHelper;
@@ -55,6 +56,16 @@ public class UserLogsInIntegrationTests extends IntegrationTestHelper {
         final AuthnRequestSteps.Cookies cookies = authnRequestSteps.userPostsAuthnRequestToStubIdp();
         authnRequestSteps.userLogsIn(cookies);
         authnRequestSteps.userConsentsReturnSamlResponse(cookies, false);
+    }
+
+    @Test
+    @Ignore
+    public void testStaleSessionReaper() throws InterruptedException {
+        // set times in StaleSessionReaperConfiguration to 1s, run this test and check the log lines
+        for(int i=0;i<10;i++) {
+            authnRequestSteps.userPostsAuthnRequestToStubIdp();
+            Thread.sleep(1000);
+        }
     }
 
     @Test

--- a/stub-idp/src/integration-test/java/uk/gov/ida/apprule/support/StubIdpAppRule.java
+++ b/stub-idp/src/integration-test/java/uk/gov/ida/apprule/support/StubIdpAppRule.java
@@ -38,7 +38,7 @@ public class StubIdpAppRule extends DropwizardAppRule<StubIdpConfiguration> {
     private final List<StubIdp> stubIdps = new ArrayList<>();
 
     public StubIdpAppRule(ConfigOverride... configOverrides) {
-        super(StubIdpApplication.class, ResourceHelpers.resourceFilePath("stub-idp.yml"), withDefaultOverrides(configOverrides));
+        super(StubIdpApplication.class, "configuration/stub-idp.yml", withDefaultOverrides(configOverrides));
     }
 
     public static ConfigOverride[] withDefaultOverrides(ConfigOverride ... configOverrides) {

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -56,6 +56,7 @@ import uk.gov.ida.stub.idp.repositories.jdbc.JDBIEidasSessionRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.JDBIIdpSessionRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.JDBIUserRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.UserMapper;
+import uk.gov.ida.stub.idp.repositories.reaper.ManagedStaleSessionReaper;
 import uk.gov.ida.stub.idp.saml.locators.IdpHardCodedEntityToEncryptForLocator;
 import uk.gov.ida.stub.idp.saml.transformers.EidasResponseTransformerProvider;
 import uk.gov.ida.stub.idp.saml.transformers.OutboundResponseFromIdpTransformerProvider;
@@ -141,6 +142,8 @@ public class StubIdpModule extends AbstractModule {
         
         bind(new TypeLiteral<SessionRepository<IdpSession>>(){}).to(IdpSessionRepository.class);
         bind(new TypeLiteral<SessionRepository<EidasSession>>(){}).to(EidasSessionRepository.class);
+
+        bind(ManagedStaleSessionReaper.class).asEagerSingleton();
 
         bind(HmacValidator.class);
         bind(HmacDigest.class);

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/configuration/StubIdpConfiguration.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/configuration/StubIdpConfiguration.java
@@ -11,6 +11,7 @@ import uk.gov.ida.configuration.ServiceNameConfiguration;
 import uk.gov.ida.saml.idp.configuration.SamlConfiguration;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
+import uk.gov.ida.stub.idp.repositories.reaper.StaleSessionReaperConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -94,6 +95,11 @@ public class StubIdpConfiguration extends Configuration implements
     @JsonProperty
     private SingleIdpConfiguration singleIdpJourney;
 
+    @NotNull
+    @Valid
+    @JsonProperty
+    private StaleSessionReaperConfiguration staleSessionReaperConfiguration = new StaleSessionReaperConfiguration();
+
     protected StubIdpConfiguration() {
     }
 
@@ -156,4 +162,8 @@ public class StubIdpConfiguration extends Configuration implements
     }
 
     public SingleIdpConfiguration getSingleIdpJourneyConfiguration() { return singleIdpJourney; }
+
+    public StaleSessionReaperConfiguration getStaleSessionReaperConfiguration() {
+        return staleSessionReaperConfiguration;
+    }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/SessionRepository.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/SessionRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.stub.idp.repositories;
 
+import org.joda.time.Duration;
 import uk.gov.ida.common.SessionId;
 
 import java.util.Optional;
@@ -10,4 +11,7 @@ public interface SessionRepository<T extends Session> {
 	SessionId updateSession(SessionId sessionToken, Session session);
 	void deleteSession(SessionId sessionToken);
 	Optional<T> deleteAndGet(SessionId sessionToken);
+	long countSessionsOlderThan(Duration duration);
+	void deleteSessionsOlderThan(Duration duration);
+	long countSessionsInDatabase();
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/ManagedStaleSessionReaper.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/ManagedStaleSessionReaper.java
@@ -21,19 +21,24 @@ public class ManagedStaleSessionReaper implements Managed {
     private final ScheduledExecutorService scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
     private final StaleSessionReaperConfiguration staleSessionReaperConfiguration;
     private final SessionRepository<IdpSession> verifySessionRepository;
+    private final long terminationTimeoutSeconds;
+    private final int reaperFrequencyInSeconds;
 
     @Inject
     public ManagedStaleSessionReaper(StubIdpConfiguration stubIdpConfiguration,
                                      SessionRepository<IdpSession> verifySessionRepository) {
         this.staleSessionReaperConfiguration = stubIdpConfiguration.getStaleSessionReaperConfiguration();
         this.verifySessionRepository = verifySessionRepository;
+        this.terminationTimeoutSeconds = staleSessionReaperConfiguration.getTerminationTimeout().getStandardSeconds();
+        this.reaperFrequencyInSeconds = staleSessionReaperConfiguration.getReaperFrequency().toStandardSeconds().getSeconds();
     }
 
     @Override
     public void start() throws Exception {
-        scheduledExecutorService.scheduleWithFixedDelay(new StaleSessionReaper(verifySessionRepository, staleSessionReaperConfiguration),
-                staleSessionReaperConfiguration.getReaperFrequency().toStandardSeconds().getSeconds(),
-                staleSessionReaperConfiguration.getReaperFrequency().toStandardSeconds().getSeconds(),
+        final StaleSessionReaper staleSessionReaper = new StaleSessionReaper(verifySessionRepository, staleSessionReaperConfiguration);
+        scheduledExecutorService.scheduleWithFixedDelay(staleSessionReaper,
+                reaperFrequencyInSeconds,
+                reaperFrequencyInSeconds,
                 TimeUnit.SECONDS);
     }
 
@@ -42,7 +47,7 @@ public class ManagedStaleSessionReaper implements Managed {
         LOGGER.info("shutting down; waiting for any active reapers to finish");
         scheduledExecutorService.shutdown();
         try {
-            scheduledExecutorService.awaitTermination(60, TimeUnit.SECONDS);
+            scheduledExecutorService.awaitTermination(terminationTimeoutSeconds, TimeUnit.SECONDS);
         } catch(InterruptedException e) {
             LOGGER.warn("reaper was terminated before it had completed running");
         }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/ManagedStaleSessionReaper.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/ManagedStaleSessionReaper.java
@@ -1,0 +1,50 @@
+package uk.gov.ida.stub.idp.repositories.reaper;
+
+import io.dropwizard.lifecycle.Managed;
+import org.apache.log4j.Logger;
+import uk.gov.ida.stub.idp.configuration.StubIdpConfiguration;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
+import uk.gov.ida.stub.idp.repositories.SessionRepository;
+
+import javax.inject.Inject;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Delete stale sessions
+ */
+public class ManagedStaleSessionReaper implements Managed {
+
+    private static final Logger LOGGER = Logger.getLogger(ManagedStaleSessionReaper.class);
+
+    private final ScheduledExecutorService scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
+    private final StaleSessionReaperConfiguration staleSessionReaperConfiguration;
+    private final SessionRepository<IdpSession> verifySessionRepository;
+
+    @Inject
+    public ManagedStaleSessionReaper(StubIdpConfiguration stubIdpConfiguration,
+                                     SessionRepository<IdpSession> verifySessionRepository) {
+        this.staleSessionReaperConfiguration = stubIdpConfiguration.getStaleSessionReaperConfiguration();
+        this.verifySessionRepository = verifySessionRepository;
+    }
+
+    @Override
+    public void start() throws Exception {
+        scheduledExecutorService.scheduleWithFixedDelay(new StaleSessionReaper(verifySessionRepository, staleSessionReaperConfiguration),
+                staleSessionReaperConfiguration.getReaperFrequency().toStandardSeconds().getSeconds(),
+                staleSessionReaperConfiguration.getReaperFrequency().toStandardSeconds().getSeconds(),
+                TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        LOGGER.info("shutting down; waiting for any active reapers to finish");
+        scheduledExecutorService.shutdown();
+        try {
+            scheduledExecutorService.awaitTermination(60, TimeUnit.SECONDS);
+        } catch(InterruptedException e) {
+            LOGGER.warn("reaper was terminated before it had completed running");
+        }
+    }
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaper.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaper.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.stub.idp.repositories.reaper;
 
 import org.apache.log4j.Logger;
+import org.joda.time.Duration;
 import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.SessionRepository;
 
@@ -14,21 +15,21 @@ public class StaleSessionReaper implements Runnable {
      * this operates on all sessions in the database, both eidas and verify
      */
     private final SessionRepository<IdpSession> verifySessionRepository;
-    private final StaleSessionReaperConfiguration staleSessionReaperConfiguration;
+    private final Duration sessionIsStaleAfter;
 
     public StaleSessionReaper(SessionRepository<IdpSession> verifySessionRepository,
                               StaleSessionReaperConfiguration staleSessionReaperConfiguration) {
         this.verifySessionRepository = verifySessionRepository;
-        this.staleSessionReaperConfiguration = staleSessionReaperConfiguration;
+        this.sessionIsStaleAfter = staleSessionReaperConfiguration.getSessionIsStaleAfter();
     }
 
     @Override
     public void run() {
         final long sessionsInDatabaseBefore = verifySessionRepository.countSessionsInDatabase();
         LOGGER.info(format("{0} active sessions before reaping (eidas + verify)", sessionsInDatabaseBefore));
-        final long staleSessionsToReap = verifySessionRepository.countSessionsOlderThan(staleSessionReaperConfiguration.getSessionIsStaleAfter());
+        final long staleSessionsToReap = verifySessionRepository.countSessionsOlderThan(sessionIsStaleAfter);
         LOGGER.info(format("{0} session(s) (approx) are expected to be reaped (eidas + verify)", staleSessionsToReap));
-        verifySessionRepository.deleteSessionsOlderThan(staleSessionReaperConfiguration.getSessionIsStaleAfter());
+        verifySessionRepository.deleteSessionsOlderThan(sessionIsStaleAfter);
         final long sessionsInDatabaseAfter = verifySessionRepository.countSessionsInDatabase();
         LOGGER.info(format("{0} active sessions after reaping (eidas + verify)", sessionsInDatabaseAfter));
     }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaper.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaper.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.stub.idp.repositories.reaper;
+
+import org.apache.log4j.Logger;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
+import uk.gov.ida.stub.idp.repositories.SessionRepository;
+
+import static java.text.MessageFormat.format;
+
+public class StaleSessionReaper implements Runnable {
+
+    private static final Logger LOGGER = Logger.getLogger(StaleSessionReaper.class);
+
+    /**
+     * this operates on all sessions in the database, both eidas and verify
+     */
+    private final SessionRepository<IdpSession> verifySessionRepository;
+    private final StaleSessionReaperConfiguration staleSessionReaperConfiguration;
+
+    public StaleSessionReaper(SessionRepository<IdpSession> verifySessionRepository,
+                              StaleSessionReaperConfiguration staleSessionReaperConfiguration) {
+        this.verifySessionRepository = verifySessionRepository;
+        this.staleSessionReaperConfiguration = staleSessionReaperConfiguration;
+    }
+
+    @Override
+    public void run() {
+        final long sessionsInDatabaseBefore = verifySessionRepository.countSessionsInDatabase();
+        LOGGER.info(format("{0} active sessions before reaping (eidas + verify)", sessionsInDatabaseBefore));
+        final long staleSessionsToReap = verifySessionRepository.countSessionsOlderThan(staleSessionReaperConfiguration.getSessionIsStaleAfter());
+        LOGGER.info(format("{0} session(s) (approx) are expected to be reaped (eidas + verify)", staleSessionsToReap));
+        verifySessionRepository.deleteSessionsOlderThan(staleSessionReaperConfiguration.getSessionIsStaleAfter());
+        final long sessionsInDatabaseAfter = verifySessionRepository.countSessionsInDatabase();
+        LOGGER.info(format("{0} active sessions after reaping (eidas + verify)", sessionsInDatabaseAfter));
+    }
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaperConfiguration.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaperConfiguration.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.stub.idp.repositories.reaper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.Duration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class StaleSessionReaperConfiguration {
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Duration sessionIsStaleAfter = Duration.standardHours(4);
+
+    @NotNull
+    @Valid
+    @JsonProperty
+    private Duration reaperFrequency = Duration.standardHours(1);
+
+    public StaleSessionReaperConfiguration() {}
+
+    public Duration getSessionIsStaleAfter() {
+        return sessionIsStaleAfter;
+    }
+
+    public Duration getReaperFrequency() {
+        return reaperFrequency;
+    }
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaperConfiguration.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/reaper/StaleSessionReaperConfiguration.java
@@ -18,6 +18,12 @@ public class StaleSessionReaperConfiguration {
     @JsonProperty
     private Duration reaperFrequency = Duration.standardHours(1);
 
+    @NotNull
+    @Valid
+    @JsonProperty
+    // this is 30 in the upstart script so this gives a bit more time for cleanup before termination
+    private Duration terminationTimeout = Duration.standardSeconds(20);
+
     public StaleSessionReaperConfiguration() {}
 
     public Duration getSessionIsStaleAfter() {
@@ -26,5 +32,9 @@ public class StaleSessionReaperConfiguration {
 
     public Duration getReaperFrequency() {
         return reaperFrequency;
+    }
+
+    public Duration getTerminationTimeout() {
+        return terminationTimeout;
     }
 }

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepositoryTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepositoryTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.stub.idp.repositories.jdbc;
 import org.jdbi.v3.core.Jdbi;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,7 +34,24 @@ public class JDBIIdpSessionRepositoryTest {
 		jdbi = Jdbi.create(DATABASE_URL);
 		repository = new JDBIIdpSessionRepository(jdbi);
 	}
-	
+
+	@Test
+	public void testSessionDeletion() {
+		assertThat(repository.countSessionsInDatabase()).isZero();
+		repository.createSession(createSession());
+		assertThat(repository.countSessionsInDatabase()).isEqualTo(1);
+		assertThat(repository.countSessionsOlderThan(Duration.standardHours(1))).isEqualTo(0);
+		assertThat(repository.countSessionsOlderThan(Duration.ZERO)).isEqualTo(1);
+		repository.deleteSessionsOlderThan(Duration.ZERO);
+		assertThat(repository.countSessionsInDatabase()).isZero();
+	}
+
+	private IdpSession createSession() {
+		DateTime authnRequestIssueTime = new DateTime(2018, 4, 25, 11, 24, 0, DateTimeZone.UTC);
+		IdaAuthnRequestFromHub authnRequest = new IdaAuthnRequestFromHub("155a37d3-5a9d-4cd0-b68a-158717b85202", "test-issuer", authnRequestIssueTime, Arrays.asList(), Optional.empty(), null, null, AuthnContextComparisonTypeEnumeration.EXACT);
+		return createSession(authnRequest);
+	}
+
 	@Test
 	public void createSession_shouldCreateIdpSessionAndStoreInDatabase() {
 		DateTime authnRequestIssueTime = new DateTime(2018, 4, 25, 11, 24, 0, DateTimeZone.UTC);

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepositoryTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIIdpSessionRepositoryTest.java
@@ -37,7 +37,9 @@ public class JDBIIdpSessionRepositoryTest {
 
 	@Test
 	public void testSessionDeletion() {
-		assertThat(repository.countSessionsInDatabase()).isZero();
+		// force clear all sessions from the test database
+		repository.deleteSessionsOlderThan(Duration.ZERO);
+		assertThat(repository.countSessionsInDatabase()).isZero().withFailMessage("found %d sessions in the database when it should be empty", repository.countSessionsInDatabase());
 		repository.createSession(createSession());
 		assertThat(repository.countSessionsInDatabase()).isEqualTo(1);
 		assertThat(repository.countSessionsOlderThan(Duration.standardHours(1))).isEqualTo(0);


### PR DESCRIPTION
Will close this in a week or so if it's not got any take up.  I'm not really sure how to test this.  I've run it locally by changing the config to 1s and checking the logs - see the ignored test.

interesting to note that it's not possible to separately count verify
vs eidas sessions

Closes #37