### PR TITLE
BAU: Add eIDAS Stub IDP API

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpApplication.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpApplication.java
@@ -41,6 +41,7 @@ import uk.gov.ida.stub.idp.resources.eidas.EidasDebugPageResource;
 import uk.gov.ida.stub.idp.resources.eidas.EidasLoginPageResource;
 import uk.gov.ida.stub.idp.resources.eidas.EidasProxyNodeServiceMetadataResource;
 import uk.gov.ida.stub.idp.resources.eidas.EidasRegistrationPageResource;
+import uk.gov.ida.stub.idp.resources.eidas.EidasUserResource;
 import uk.gov.ida.stub.idp.resources.idp.ConsentResource;
 import uk.gov.ida.stub.idp.resources.idp.DebugPageResource;
 import uk.gov.ida.stub.idp.resources.idp.HeadlessIdpResource;
@@ -136,6 +137,7 @@ public class StubIdpApplication extends Application<StubIdpConfiguration> {
         environment.jersey().register(DebugPageResource.class);
         environment.jersey().register(ConsentResource.class);
         environment.jersey().register(UserResource.class);
+        environment.jersey().register(EidasUserResource.class);
         environment.jersey().register(HeadlessIdpResource.class);
         environment.jersey().register(GeneratePasswordResource.class);
         environment.jersey().register(EidasProxyNodeServiceMetadataResource.class);

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -137,6 +137,7 @@ public class StubIdpModule extends AbstractModule {
         bind(IdpUserService.class);
         bind(StubCountryService.class);
         bind(UserService.class);
+        bind(EidasUserService.class);
         bind(SamlResponseRedirectViewFactory.class);
         
         bind(new TypeLiteral<SessionRepository<IdpSession>>(){}).to(IdpSessionRepository.class);

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/Urls.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/Urls.java
@@ -63,7 +63,8 @@ public interface Urls {
     String DELETE_USER_PATH = "/delete";
     String GET_USER_PATH = "/{" + USERNAME_PARAM + "}";
 
+    String EIDAS_USERS_RESOURCE = "/eidas/{"+SCHEME_ID_PARAM+"}/users";
+
     @SuppressWarnings("squid:S2068")
     String PASSWORD_GEN_RESOURCE = "/password-gen";
-
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/builders/EidasUserDtoBuilder.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/builders/EidasUserDtoBuilder.java
@@ -1,0 +1,83 @@
+package uk.gov.ida.stub.idp.builders;
+
+import org.joda.time.LocalDate;
+import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
+import uk.gov.ida.stub.idp.dtos.EidasUserDto;
+
+import java.util.Optional;
+
+public class EidasUserDtoBuilder {
+
+    private Optional<String> pid = Optional.empty();
+    private MatchingDatasetValue<String> firstName;
+    private Optional<MatchingDatasetValue<String>> firstNameNonLatin = Optional.empty();
+    private MatchingDatasetValue<String> familyName;
+    private Optional<MatchingDatasetValue<String>> familyNameNonLatin = Optional.empty();
+    private MatchingDatasetValue<LocalDate> dateOfBirth;
+    private String userName;
+    private String password;
+    private String levelOfAssurance;
+
+    public static EidasUserDtoBuilder anEidasUserDto() {
+        return new EidasUserDtoBuilder();
+    }
+
+    public EidasUserDto build() {
+        return new EidasUserDto(
+                pid,
+                userName,
+                password,
+                firstName,
+                firstNameNonLatin,
+                familyName,
+                familyNameNonLatin,
+                dateOfBirth,
+                levelOfAssurance
+        );
+    }
+
+    public EidasUserDtoBuilder withPid(String pid) {
+        this.pid = Optional.ofNullable(pid);
+        return this;
+    }
+
+    public EidasUserDtoBuilder withUserName(final String userName) {
+        this.userName = userName;
+        return this;
+    }
+
+    public EidasUserDtoBuilder withPassword(final String password) {
+        this.password = password;
+        return this;
+    }
+
+    public EidasUserDtoBuilder withFirsName(final MatchingDatasetValue<String> firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    public EidasUserDtoBuilder withFirstNameNonLatin(final MatchingDatasetValue<String> firstNameNonLatin) {
+        this.firstNameNonLatin = Optional.ofNullable(firstNameNonLatin);
+        return this;
+    }
+
+    public EidasUserDtoBuilder withFamilyName(final MatchingDatasetValue<String> familyName) {
+        this.familyName = familyName;
+        return this;
+    }
+
+    public EidasUserDtoBuilder withFamilyNameNonLatin(final MatchingDatasetValue<String> familyNameNonLatin) {
+        this.familyNameNonLatin = Optional.of(familyNameNonLatin);
+        return this;
+    }
+
+    public EidasUserDtoBuilder withDateOfBirth(final MatchingDatasetValue<LocalDate> dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+        return this;
+    }
+
+    public EidasUserDtoBuilder withLevelOfAssurance(final String levelOfAssurance) {
+        this.levelOfAssurance = levelOfAssurance;
+        return this;
+    }
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/dtos/EidasUserDto.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/dtos/EidasUserDto.java
@@ -1,0 +1,100 @@
+package uk.gov.ida.stub.idp.dtos;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.LocalDate;
+import uk.gov.ida.stub.idp.domain.DatabaseEidasUser;
+import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
+
+import java.util.Optional;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class EidasUserDto {
+
+    private Optional<String> pid = Optional.empty();
+    private String username;
+    private String password;
+    private MatchingDatasetValue<String> firstName;
+    private Optional<MatchingDatasetValue<String>> firstNameNonLatin = Optional.empty();
+    private MatchingDatasetValue<String> familyName;
+    private Optional<MatchingDatasetValue<String>> familyNameNonLatin = Optional.empty();
+    private MatchingDatasetValue<LocalDate> dateOfBirth;
+    private String levelOfAssurance;
+
+    @SuppressWarnings("unused")
+    private EidasUserDto() {}
+
+    @JsonCreator
+    public EidasUserDto(
+            @JsonProperty("pid") Optional<String> pid,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password,
+            @JsonProperty("firstName") MatchingDatasetValue<String> firstName,
+            @JsonProperty("firstNameNonLatin") Optional<MatchingDatasetValue<String>> firstNameNonLatin,
+            @JsonProperty("surname") MatchingDatasetValue<String> familyName,
+            @JsonProperty("surnameNonLatin") Optional<MatchingDatasetValue<String>> familyNameNonLatin,
+            @JsonProperty("dateOfBirth") MatchingDatasetValue<LocalDate> dateOfBirth,
+            @JsonProperty("levelOfAssurance") String levelOfAssurance) {
+
+        this.pid = pid;
+        this.username = username;
+        this.password = password;
+        this.firstName = firstName;
+        this.firstNameNonLatin = firstNameNonLatin;
+        this.familyName = familyName;
+        this.familyNameNonLatin = familyNameNonLatin;
+        this.dateOfBirth = dateOfBirth;
+        this.levelOfAssurance = levelOfAssurance;
+    }
+
+    public Optional<String> getPid() {
+        return Optional.ofNullable(pid).get();
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public MatchingDatasetValue<String> getFirstName() {
+        return firstName;
+    }
+
+    public Optional<MatchingDatasetValue<String>> getFirstNameNonLatin() {
+        return firstNameNonLatin;
+    }
+
+    public MatchingDatasetValue<String> getFamilyName() {
+        return familyName;
+    }
+
+    public Optional<MatchingDatasetValue<String>> getFamilyNameNonLatin() {
+        return familyNameNonLatin;
+    }
+
+    public MatchingDatasetValue<LocalDate> getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public String getLevelOfAssurance() {
+        return levelOfAssurance;
+    }
+
+    public static EidasUserDto fromEidasUser(DatabaseEidasUser eidasUser) {
+        return new EidasUserDto(
+                Optional.ofNullable(eidasUser.getPersistentId()),
+                eidasUser.getUsername(),
+                eidasUser.getPassword(),
+                eidasUser.getFirstname(),
+                eidasUser.getNonLatinFirstname(),
+                eidasUser.getSurname(),
+                eidasUser.getNonLatinSurname(),
+                eidasUser.getDateOfBirth(),
+                eidasUser.getLevelOfAssurance().toString()
+        );
+    }
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/AllIdpsUserRepository.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/AllIdpsUserRepository.java
@@ -101,6 +101,10 @@ public class AllIdpsUserRepository {
         return userRepository.getUsersForIdp(idpFriendlyName);
     }
 
+    public Collection<DatabaseEidasUser> getAllUsersForStubCountry(String eidasSchemeName) {
+        return userRepository.getUsersForCountry(eidasSchemeName);
+    }
+
     public Optional<DatabaseIdpUser> getUserForIdp(String idpFriendlyName, String username) {
         final List<DatabaseIdpUser> matchingUsers = userRepository.getUsersForIdp(idpFriendlyName)
                 .stream()
@@ -140,5 +144,10 @@ public class AllIdpsUserRepository {
     public void deleteUserFromIdp(String idpFriendlyName, String username) {
         LOG.debug("Deleting user " + username + " from IDP " + idpFriendlyName);
         userRepository.deleteUserFromIdp(idpFriendlyName, username);
+    }
+
+    public void deleteUserFromStubCountry(String eidasSchemeName, String username) {
+        LOG.debug("Deleting user " + username + " from IDP " + eidasSchemeName);
+        userRepository.deleteEidasUserFromStubCountry(eidasSchemeName, username);
     }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/StubCountry.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/StubCountry.java
@@ -5,6 +5,7 @@ import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.stub.idp.domain.DatabaseEidasUser;
 import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -68,5 +69,17 @@ public class StubCountry {
 
     public boolean userExists(String username) {
         return allIdpsUserRepository.containsUserForIdp(friendlyId, username);
+    }
+
+    public Optional<DatabaseEidasUser> getUser(String username) {
+        return allIdpsUserRepository.getUserForCountry(friendlyId, username);
+    }
+
+    public Collection<DatabaseEidasUser> getAllUsers() {
+        return allIdpsUserRepository.getAllUsersForStubCountry(friendlyId);
+    }
+
+    public void deleteUser(String username) {
+        allIdpsUserRepository.deleteUserFromStubCountry(friendlyId, username);
     }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/UserRepository.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/UserRepository.java
@@ -2,7 +2,6 @@ package uk.gov.ida.stub.idp.repositories;
 
 import uk.gov.ida.stub.idp.domain.DatabaseEidasUser;
 import uk.gov.ida.stub.idp.domain.DatabaseIdpUser;
-import uk.gov.ida.stub.idp.domain.EidasUser;
 
 import java.util.Collection;
 
@@ -11,5 +10,6 @@ public interface UserRepository {
     void addOrUpdateUserForIdp(String idpFriendlyName, DatabaseIdpUser user);
     void addOrUpdateEidasUserForStubCountry(String stubCountryName, DatabaseEidasUser eidasUser);
     void deleteUserFromIdp(String idpFriendlyName, String username);
+    void deleteEidasUserFromStubCountry(String eidasSchemeName, String username);
     Collection<DatabaseEidasUser> getUsersForCountry(String friendlyName);
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIUserRepository.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/JDBIUserRepository.java
@@ -94,6 +94,19 @@ public class JDBIUserRepository implements UserRepository {
     }
 
     @Override
+    public void deleteEidasUserFromStubCountry(String eidasSchemeName, String username) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate(
+                        "DELETE FROM users " +
+                                "WHERE identity_provider_friendly_id = :eidasSchemeName " +
+                                "AND username = :username")
+                        .bind("eidasSchemeName", eidasSchemeName)
+                        .bind("username", username)
+                        .execute()
+        );
+    }
+
+    @Override
     public Collection<DatabaseEidasUser> getUsersForCountry(String friendlyName) {
         List<User> users = jdbi.withHandle(handle ->
                 handle.createQuery(

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/resources/eidas/EidasUserResource.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/resources/eidas/EidasUserResource.java
@@ -1,0 +1,92 @@
+package uk.gov.ida.stub.idp.resources.eidas;
+
+import uk.gov.ida.stub.idp.Urls;
+import uk.gov.ida.stub.idp.dtos.EidasUserDto;
+import uk.gov.ida.stub.idp.exceptions.IdpUserNotFoundException;
+import uk.gov.ida.stub.idp.services.EidasUserService;
+import uk.gov.ida.stub.idp.validation.ValidationResponse;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.text.MessageFormat.format;
+import static java.util.Arrays.asList;
+
+@Path(Urls.EIDAS_USERS_RESOURCE)
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class EidasUserResource {
+
+    private final EidasUserService userService;
+
+    @Inject
+    public EidasUserResource(EidasUserService userService) {
+        this.userService = userService;
+    }
+
+    @GET
+    public Collection<EidasUserDto> getAllUsers(@PathParam(Urls.SCHEME_ID_PARAM) String schemeName) {
+        return userService.getIdpUserDtos(schemeName);
+    }
+
+    @GET
+    @Path(Urls.GET_USER_PATH)
+    public EidasUserDto getUser(
+            @PathParam(Urls.SCHEME_ID_PARAM) @NotNull String schemeName,
+            @PathParam(Urls.USERNAME_PARAM) @NotNull String username) {
+
+        Optional<EidasUserDto> user = userService.getUser(schemeName, username);
+        if (user.isPresent()) return user.get();
+
+        throw new IdpUserNotFoundException(format("user not found: {0}", username));
+    }
+
+    @POST
+    public Response createUsers(
+            @PathParam(Urls.SCHEME_ID_PARAM) @NotNull String schemeName,
+            @NotNull EidasUserDto... users) {
+
+        List<ValidationResponse> validationResponses = userService.validateUsers(asList(users));
+
+        if(validationResponses.stream().anyMatch(validationResponse -> !validationResponse.isOk())) {
+            final List<String> validationMessages = validationResponses.stream()
+                    .filter(validationResponse -> !validationResponse.isOk())
+                    .map(ValidationResponse::getMessages)
+                    .flatMap(List::stream)
+                    .collect(Collectors.toList());
+            return Response.status(Response.Status.BAD_REQUEST).entity(validationMessages).build();
+        }
+
+        EidasUserService.ResponseMessage responseMessage = userService.createUsers(schemeName, users);
+
+        return Response.created(UriBuilder.fromPath("").build())
+                .entity(Entity.json(responseMessage))
+                .build();
+    }
+
+    @POST
+    @Path(Urls.DELETE_USER_PATH)
+    public Response deleteUser(
+            @PathParam(Urls.SCHEME_ID_PARAM) @NotNull String schemeName,
+            @NotNull EidasUserDto userToDelete) {
+        final EidasUserService.ResponseMessage responseMessage = userService.deleteUser(schemeName, userToDelete);
+
+        return Response.ok(UriBuilder.fromPath("").build())
+                .entity(Entity.json(responseMessage))
+                .build();
+    }
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/services/EidasUserService.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/services/EidasUserService.java
@@ -1,0 +1,139 @@
+package uk.gov.ida.stub.idp.services;
+
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.stub.idp.Urls;
+import uk.gov.ida.stub.idp.domain.DatabaseEidasUser;
+import uk.gov.ida.stub.idp.domain.EidasScheme;
+import uk.gov.ida.stub.idp.dtos.EidasUserDto;
+import uk.gov.ida.stub.idp.exceptions.InvalidEidasSchemeException;
+import uk.gov.ida.stub.idp.repositories.StubCountry;
+import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
+import uk.gov.ida.stub.idp.validation.ValidationResponse;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.PathParam;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class EidasUserService {
+
+    public class ResponseMessage {
+        private String message;
+
+        private ResponseMessage(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    private final StubCountryRepository stubCountryRepository;
+
+    @Inject
+    public EidasUserService(StubCountryRepository stubCountryRepository) {
+        this.stubCountryRepository = stubCountryRepository;
+    }
+
+    public Optional<EidasUserDto> getUser(String schemeName, String username) {
+        return getStubCountryForSchemeName(schemeName).getUser(username).map(this::transform);
+    }
+
+    public ResponseMessage createUsers(@PathParam(Urls.SCHEME_ID_PARAM) @NotNull String schemeName, @NotNull EidasUserDto[] users) {
+        final StubCountry stubCountry = getStubCountryForSchemeName(schemeName);
+
+        createEidasUsers(stubCountry, users);
+
+        return new ResponseMessage("Users created.");
+    }
+
+    public ResponseMessage deleteUser(@PathParam(Urls.SCHEME_ID_PARAM) @NotNull String schemeName, @NotNull EidasUserDto userToDelete) {
+        final StubCountry stubCountry = getStubCountryForSchemeName(schemeName);
+
+        deleteEidasUser(stubCountry, userToDelete);
+
+        return new ResponseMessage("User " + userToDelete.getUsername() + " deleted.");
+    }
+
+    public Collection<EidasUserDto> getIdpUserDtos(@PathParam(Urls.SCHEME_ID_PARAM) String schemeName) {
+        final StubCountry stubCountry = getStubCountryForSchemeName(schemeName);
+        return stubCountry.getAllUsers().stream().map(this::transform).collect(Collectors.toList());
+    }
+
+    public List<ValidationResponse> validateUsers(List<EidasUserDto> users) {
+        List<ValidationResponse> validationResponses = new ArrayList<>();
+        for (EidasUserDto user : users) {
+            validationResponses.add(validateUser(user));
+        }
+        return validationResponses;
+    }
+
+    private ValidationResponse validateUser(EidasUserDto user) {
+        List<String> messages = new ArrayList<>();
+        if (user.getLevelOfAssurance() == null) {
+            messages.add("Level of Assurance was not specified.");
+        } else {
+            try {
+                AuthnContext.valueOf(user.getLevelOfAssurance());
+            } catch (IllegalArgumentException e) {
+                messages.add(user.getLevelOfAssurance() + ": Level of Assurance supplied was not valid.");
+            }
+        }
+
+        if (user.getUsername() == null || user.getUsername().isEmpty()) {
+            messages.add("Username was not specified or was empty.");
+        }
+
+        if (user.getPassword() == null || user.getPassword().isEmpty()) {
+            messages.add("Password was not specified or was empty.");
+        }
+
+        if (messages.isEmpty()) {
+            return ValidationResponse.aValidResponse();
+        } else {
+            return ValidationResponse.anInvalidResponse(messages);
+        }
+    }
+
+    private void createEidasUsers(StubCountry stubCountry, EidasUserDto[] users) {
+        for (EidasUserDto user : users) {
+            createEidasUser(stubCountry, user);
+        }
+    }
+
+    private void createEidasUser(StubCountry stubCountry, EidasUserDto user) {
+        stubCountry.createUser(
+                user.getUsername(),
+                user.getPassword(),
+                user.getFirstName(),
+                user.getFirstNameNonLatin(),
+                user.getFamilyName(),
+                user.getFamilyNameNonLatin(),
+                user.getDateOfBirth(),
+                AuthnContext.valueOf(user.getLevelOfAssurance())
+        );
+    }
+
+    private void deleteEidasUser(StubCountry stubCountry, EidasUserDto userToDelete) {
+        stubCountry.deleteUser(userToDelete.getUsername());
+    }
+
+    private EidasUserDto transform(DatabaseEidasUser eidasUser) {
+        return EidasUserDto.fromEidasUser(eidasUser);
+    }
+
+    private StubCountry getStubCountryForSchemeName(String schemeName) {
+        final Optional<EidasScheme> eidasScheme = EidasScheme.fromString(schemeName);
+
+        if(!eidasScheme.isPresent()) {
+            throw new InvalidEidasSchemeException();
+        }
+
+        return stubCountryRepository.getStubCountryWithFriendlyId(eidasScheme.get());
+    }
+}

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/builders/EidasUserBuilder.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/builders/EidasUserBuilder.java
@@ -1,0 +1,81 @@
+package uk.gov.ida.stub.idp.builders;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import uk.gov.ida.saml.core.domain.Address;
+import uk.gov.ida.saml.core.domain.AuthnContext;
+import uk.gov.ida.stub.idp.domain.DatabaseEidasUser;
+import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.emptyList;
+import static uk.gov.ida.saml.core.domain.AuthnContext.LEVEL_1;
+
+public class EidasUserBuilder {
+
+    private String username = "default-username";
+    private String persistentId = "default-persistent-id";
+    private String password = "default-password";
+    private List<Address> addresses = emptyList();
+    private AuthnContext levelOfAssurance = LEVEL_1;
+    private MatchingDatasetValue<String> firstName = new MatchingDatasetValue<>(
+            "default-first-name",
+            DateTime.now().minusYears(20),
+            null,
+            true
+    );
+    private MatchingDatasetValue<String> firstNameNonLatin = new MatchingDatasetValue<>(
+            "default-first-name-non-latin",
+            DateTime.now().minusYears(20),
+            null,
+            true
+    );
+    private MatchingDatasetValue<String> familyName = new MatchingDatasetValue<>(
+            "default-family-name",
+            DateTime.now().minusYears(20),
+            null,
+            true
+    );
+    private MatchingDatasetValue<String> familyNameNonLatin = new MatchingDatasetValue<>(
+            "default-family-name-non-latin",
+            DateTime.now().minusYears(20),
+            null,
+            true
+    );
+    private MatchingDatasetValue<LocalDate> dateOfBirth = new MatchingDatasetValue<>(
+            LocalDate.now().minusYears(20),
+            DateTime.now().minusYears(20),
+            null,
+            true
+    );
+
+    public static EidasUserBuilder anEidasUser() {
+        return new EidasUserBuilder();
+    }
+
+    public DatabaseEidasUser build() {
+        return new DatabaseEidasUser(
+                username,
+                persistentId,
+                password,
+                firstName,
+                Optional.of(firstNameNonLatin),
+                familyName,
+                Optional.of(familyNameNonLatin),
+                dateOfBirth,
+                levelOfAssurance
+        );
+    }
+
+    public EidasUserBuilder withUsername(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public EidasUserBuilder withPassword(String password) {
+        this.password = password;
+        return this;
+    }
+}

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/dtos/EidasUserDtoTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/dtos/EidasUserDtoTest.java
@@ -1,0 +1,99 @@
+package uk.gov.ida.stub.idp.dtos;
+
+import io.dropwizard.jackson.Jackson;
+import org.assertj.core.api.Assertions;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import uk.gov.ida.stub.idp.builders.SimpleMdsValueBuilder;
+import uk.gov.ida.stub.idp.domain.MatchingDatasetValue;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.stub.idp.builders.EidasUserDtoBuilder.anEidasUserDto;
+
+public class EidasUserDtoTest {
+
+    @Test
+    public void shouldDeSerialiseJsonToObjectWhenAllFieldsArePopulated() throws IOException {
+
+        EidasUserDto eidasUserDtoFromJson = Jackson.newObjectMapper().readValue("{\"pid\":\"00754148-902f-4d94-b0db-cb1f7eb3fd84\",\"username\":\"user1\",\"password\":\"password\",\"firstName\":{\"value\":\"Georgios\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"firstNameNonLatin\":{\"value\":\"Γεώργιος\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"surname\":{\"value\":\"Panathinaikos\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"surnameNonLatin\":{\"value\":\"Παναθηναϊκός\",\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"dateOfBirth\":{\"value\":[1970,1,1],\"from\":315532800000,\"to\":1356998400000,\"verified\":true},\"levelOfAssurance\":\"LEVEL_2\"}", EidasUserDto.class);
+
+        EidasUserDto eidasUserDto = anEidasUserDto()
+                .withPid("00754148-902f-4d94-b0db-cb1f7eb3fd84")
+                .withUserName("user1")
+                .withPassword("password")
+                .withFirsName(createSimpleMdsValue("Georgios"))
+                .withFirstNameNonLatin(createSimpleMdsValue("Γεώργιος"))
+                .withFamilyName(createSimpleMdsValue("Panathinaikos"))
+                .withFamilyNameNonLatin(createSimpleMdsValue("Παναθηναϊκός"))
+                .withDateOfBirth(
+                        SimpleMdsValueBuilder.<LocalDate>aSimpleMdsValue()
+                                .withValue(new LocalDate(1970, 1, 1))
+                                .withFrom(new DateTime(1980, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                                .withTo(new DateTime(2013, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                                .withVerifiedStatus(true)
+                                .build()
+                )
+                .withLevelOfAssurance("LEVEL_2")
+                .build();
+
+        assertThat(compareIdpUserDto(eidasUserDtoFromJson, eidasUserDto)).isTrue();
+    }
+
+    private boolean compareIdpUserDto(final EidasUserDto eidasUserDtoFromJson, final EidasUserDto eidasUserDto) {
+
+        assertThat(eidasUserDto.getPid()).isEqualTo(eidasUserDtoFromJson.getPid());
+
+        assertThat(eidasUserDto.getUsername()).isEqualTo(eidasUserDtoFromJson.getUsername());
+
+        assertThat(eidasUserDto.getPassword()).isEqualTo(eidasUserDtoFromJson.getPassword());
+
+        MatchingDatasetValue<String> eidasUserDtoFirstName = eidasUserDto.getFirstName();
+        MatchingDatasetValue<String> eidasUserDtoFromJsonFirstName = eidasUserDtoFromJson.getFirstName();
+        compareSimpleMdsObjects(eidasUserDtoFirstName, eidasUserDtoFromJsonFirstName);
+
+        assertThat(eidasUserDto.getFirstNameNonLatin().isPresent()).isTrue();
+        assertThat(eidasUserDtoFromJson.getFirstNameNonLatin().isPresent()).isTrue();
+        MatchingDatasetValue<String> eidasUserDtoFirstNameNonLatin = eidasUserDto.getFirstNameNonLatin().get();
+        MatchingDatasetValue<String> eidasUserDtoFromJsonFirstNameNonLatin = eidasUserDtoFromJson.getFirstNameNonLatin().get();
+        compareSimpleMdsObjects(eidasUserDtoFirstNameNonLatin, eidasUserDtoFromJsonFirstNameNonLatin);
+
+        MatchingDatasetValue<String> eidasUserDtoFamilyName = eidasUserDto.getFamilyName();
+        MatchingDatasetValue<String> eidasUserDtoFromJsonFamilyName = eidasUserDtoFromJson.getFamilyName();
+        compareSimpleMdsObjects(eidasUserDtoFamilyName, eidasUserDtoFromJsonFamilyName);
+
+        assertThat(eidasUserDto.getFamilyNameNonLatin().isPresent()).isTrue();
+        assertThat(eidasUserDtoFromJson.getFamilyNameNonLatin().isPresent()).isTrue();
+        MatchingDatasetValue<String> eidasUserDtoFamilyNameNonLatin = eidasUserDto.getFamilyNameNonLatin().get();
+        MatchingDatasetValue<String> eidasUserDtoFromJsonFamilyNameNonLatin = eidasUserDtoFromJson.getFamilyNameNonLatin().get();
+        compareSimpleMdsObjects(eidasUserDtoFamilyNameNonLatin, eidasUserDtoFromJsonFamilyNameNonLatin);
+
+        MatchingDatasetValue<LocalDate> eidasUserDtoDateOfBirth = eidasUserDto.getDateOfBirth();
+        MatchingDatasetValue<LocalDate> eidasUserDtoFromJsonDateOfBirth = eidasUserDtoFromJson.getDateOfBirth();
+        compareSimpleMdsObjects(eidasUserDtoDateOfBirth, eidasUserDtoFromJsonDateOfBirth);
+
+        assertThat(eidasUserDto.getLevelOfAssurance()).isEqualTo(eidasUserDtoFromJson.getLevelOfAssurance());
+
+        return true;
+    }
+
+    private <T> void compareSimpleMdsObjects(final MatchingDatasetValue<T> firstSimpleMdsValue, final MatchingDatasetValue<T> secondSimpleMdsValue) {
+        Assertions.assertThat(firstSimpleMdsValue.getValue()).isEqualTo(secondSimpleMdsValue.getValue());
+        assertThat(firstSimpleMdsValue.getFrom().toString()).isEqualTo(secondSimpleMdsValue.getFrom().toString());
+        assertThat(firstSimpleMdsValue.getTo().toString()).isEqualTo(secondSimpleMdsValue.getTo().toString());
+        Assertions.assertThat(firstSimpleMdsValue.isVerified()).isEqualTo(secondSimpleMdsValue.isVerified());
+    }
+
+
+    private MatchingDatasetValue<String> createSimpleMdsValue(String value) {
+        return SimpleMdsValueBuilder.<String>aSimpleMdsValue()
+                .withValue(value)
+                .withFrom(new DateTime(1980, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                .withTo(new DateTime(2013, 1, 1, 0, 0, 0, DateTimeZone.UTC))
+                .withVerifiedStatus(true)
+                .build();
+    }
+}


### PR DESCRIPTION
Added ability to query and add/delete eIDAS users from stub-country via the stub IDP API

Summary of changes:
  - Added `EidasUserDto` that will be converted to/from JSON via the API
  - Added `EidasUserResource` to receive user queries and addition/deletion requests
  - Added `EidasUserService` to handle those requests
  - Added method to delete eIDAS users to the JDBI user repository
  - `StubCountry` and `AllIdpsUserRepository` now expose eIDAS user specific methods