### PR TITLE
BAU: Separate Countries and IDPs in config to fix non-prod Stub IDP journeys

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -26,9 +26,11 @@ import uk.gov.ida.common.shared.configuration.KeyConfiguration;
 import uk.gov.ida.common.shared.configuration.SecureCookieConfiguration;
 import uk.gov.ida.common.shared.configuration.SecureCookieKeyConfiguration;
 import uk.gov.ida.common.shared.configuration.SecureCookieKeyStore;
-import uk.gov.ida.common.shared.security.*;
-import uk.gov.ida.saml.security.signature.SignatureRSASSAPSS;
+import uk.gov.ida.common.shared.security.HmacDigest;
+import uk.gov.ida.common.shared.security.IdGenerator;
 import uk.gov.ida.common.shared.security.PublicKeyFactory;
+import uk.gov.ida.common.shared.security.SecureCookieKeyConfigurationKeyStore;
+import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.jerseyclient.ErrorHandlingClient;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;
@@ -39,19 +41,39 @@ import uk.gov.ida.saml.idp.configuration.SamlConfiguration;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
 import uk.gov.ida.saml.metadata.MetadataResolverConfiguration;
 import uk.gov.ida.saml.metadata.factories.DropwizardMetadataResolverFactory;
-import uk.gov.ida.saml.security.*;
+import uk.gov.ida.saml.security.EncryptionKeyStore;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+import uk.gov.ida.saml.security.SignatureFactory;
+import uk.gov.ida.saml.security.SigningKeyStore;
+import uk.gov.ida.saml.security.signature.SignatureRSASSAPSS;
 import uk.gov.ida.stub.idp.auth.ManagedAuthFilterInstaller;
 import uk.gov.ida.stub.idp.builders.CountryMetadataBuilder;
 import uk.gov.ida.stub.idp.builders.CountryMetadataSigningHelper;
-import uk.gov.ida.stub.idp.configuration.*;
+import uk.gov.ida.stub.idp.configuration.AssertionLifetimeConfiguration;
+import uk.gov.ida.stub.idp.configuration.IdpStubsConfiguration;
+import uk.gov.ida.stub.idp.configuration.SigningKeyPairConfiguration;
+import uk.gov.ida.stub.idp.configuration.SingleIdpConfiguration;
+import uk.gov.ida.stub.idp.configuration.StubIdpConfiguration;
 import uk.gov.ida.stub.idp.cookies.CookieFactory;
 import uk.gov.ida.stub.idp.cookies.HmacValidator;
 import uk.gov.ida.stub.idp.domain.factories.AssertionFactory;
 import uk.gov.ida.stub.idp.domain.factories.AssertionRestrictionsFactory;
 import uk.gov.ida.stub.idp.domain.factories.IdentityProviderAssertionFactory;
+import uk.gov.ida.stub.idp.domain.factories.IdpStubsConfigurationFactory;
 import uk.gov.ida.stub.idp.domain.factories.StubTransformersFactory;
 import uk.gov.ida.stub.idp.listeners.StubIdpsFileListener;
-import uk.gov.ida.stub.idp.repositories.*;
+import uk.gov.ida.stub.idp.repositories.AllIdpsUserRepository;
+import uk.gov.ida.stub.idp.repositories.EidasSession;
+import uk.gov.ida.stub.idp.repositories.EidasSessionRepository;
+import uk.gov.ida.stub.idp.repositories.IdpSession;
+import uk.gov.ida.stub.idp.repositories.IdpSessionRepository;
+import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
+import uk.gov.ida.stub.idp.repositories.MetadataRepository;
+import uk.gov.ida.stub.idp.repositories.SessionRepository;
+import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
+import uk.gov.ida.stub.idp.repositories.UserRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.JDBIEidasSessionRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.JDBIIdpSessionRepository;
 import uk.gov.ida.stub.idp.repositories.jdbc.JDBIUserRepository;
@@ -61,7 +83,15 @@ import uk.gov.ida.stub.idp.saml.transformers.EidasResponseTransformerProvider;
 import uk.gov.ida.stub.idp.saml.transformers.OutboundResponseFromIdpTransformerProvider;
 import uk.gov.ida.stub.idp.security.HubEncryptionKeyStore;
 import uk.gov.ida.stub.idp.security.IdaAuthnRequestKeyStore;
-import uk.gov.ida.stub.idp.services.*;
+import uk.gov.ida.stub.idp.services.AuthnRequestReceiverService;
+import uk.gov.ida.stub.idp.services.EidasAuthnResponseService;
+import uk.gov.ida.stub.idp.services.GeneratePasswordService;
+import uk.gov.ida.stub.idp.services.IdpUserService;
+import uk.gov.ida.stub.idp.services.NonSuccessAuthnResponseService;
+import uk.gov.ida.stub.idp.services.ServiceListService;
+import uk.gov.ida.stub.idp.services.StubCountryService;
+import uk.gov.ida.stub.idp.services.SuccessAuthnResponseService;
+import uk.gov.ida.stub.idp.services.UserService;
 import uk.gov.ida.stub.idp.views.SamlResponseRedirectViewFactory;
 import uk.gov.ida.truststore.EmptyKeyStoreProvider;
 
@@ -112,6 +142,7 @@ public class StubIdpModule extends AbstractModule {
         bind(AllIdpsUserRepository.class).asEagerSingleton();
 
         bind(IdpStubsRepository.class).asEagerSingleton();
+        bind(IdpStubsConfigurationFactory.class).asEagerSingleton();
         bind(KeyStore.class).toProvider(EmptyKeyStoreProvider.class).asEagerSingleton();
 
         bind(PublicKeyFactory.class);
@@ -245,8 +276,8 @@ public class StubIdpModule extends AbstractModule {
 
     @Provides
     @Singleton
-    public StubCountryRepository getStubCountryRepository(AllIdpsUserRepository allIdpsUserRepository, @Named("StubCountryMetadataUrl")String stubCountryMetadataUrl){
-        return new StubCountryRepository(allIdpsUserRepository, stubCountryMetadataUrl);
+    public StubCountryRepository getStubCountryRepository(AllIdpsUserRepository allIdpsUserRepository, @Named("StubCountryMetadataUrl")String stubCountryMetadataUrl, IdpStubsConfigurationFactory idpStubsConfigurationFactory) {
+        return new StubCountryRepository(allIdpsUserRepository, stubCountryMetadataUrl, idpStubsConfigurationFactory);
     }
 
     @Provides

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/auth/ManagedAuthFilterInstaller.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/auth/ManagedAuthFilterInstaller.java
@@ -4,6 +4,7 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import uk.gov.ida.stub.idp.configuration.StubIdpConfiguration;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
+import uk.gov.ida.stub.idp.repositories.StubCountryRepository;
 
 import javax.inject.Inject;
 import javax.servlet.DispatcherType;
@@ -18,26 +19,28 @@ public class ManagedAuthFilterInstaller implements Managed {
 
     private final StubIdpConfiguration stubIdpConfiguration;
     private final IdpStubsRepository idpStubsRepository;
+    private final StubCountryRepository stubCountryRepository;
     private final Environment environment;
 
     @Inject
-    public ManagedAuthFilterInstaller(StubIdpConfiguration stubIdpConfiguration, IdpStubsRepository idpStubsRepository, Environment environment) {
+    public ManagedAuthFilterInstaller(StubIdpConfiguration stubIdpConfiguration, IdpStubsRepository idpStubsRepository, StubCountryRepository stubCountryRepository, Environment environment) {
         this.stubIdpConfiguration = stubIdpConfiguration;
         this.idpStubsRepository = idpStubsRepository;
+        this.stubCountryRepository = stubCountryRepository;
         this.environment = environment;
     }
 
     @Override
-    public void start() throws Exception {
+    public void start() {
         if(stubIdpConfiguration.isBasicAuthEnabledForUserResource()) {
             environment.servlets()
-                    .addFilter("Basic Auth Filter for Idps", new UserResourceBasicAuthFilter(idpStubsRepository))
+                    .addFilter("Basic Auth Filter for Idps", new UserResourceBasicAuthFilter(idpStubsRepository, stubCountryRepository))
                     .addMappingForUrlPatterns(EnumSet.allOf(DispatcherType.class), true, "/*");
         }
     }
 
     @Override
-    public void stop() throws Exception {
+    public void stop() {
         // method intentionally left blank
     }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/configuration/IdpStubsConfiguration.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/configuration/IdpStubsConfiguration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.Valid;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class IdpStubsConfiguration{
 
@@ -12,6 +13,14 @@ public class IdpStubsConfiguration{
     protected Collection<StubIdp> stubIdps = null;
 
     public Collection<StubIdp> getStubIdps() {
-        return stubIdps;
+        return stubIdps.stream()
+                .filter(stub -> !stub.isEidasEnabled())
+                .collect(Collectors.toList());
+    }
+
+    public Collection<StubIdp> getStubCountries() {
+        return stubIdps.stream()
+                .filter(StubIdp::isEidasEnabled)
+                .collect(Collectors.toList());
     }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/configuration/StubIdp.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/configuration/StubIdp.java
@@ -34,6 +34,10 @@ public class StubIdp {
     @JsonProperty
     protected boolean sendKeyInfo;
 
+    @Valid
+    @JsonProperty
+    protected boolean eidasEnabled;
+
 
     public List<UserCredentials> getIdpUserCredentials() {
         return idpUserCredentials;
@@ -49,5 +53,9 @@ public class StubIdp {
 
     public boolean getSendKeyInfo() {
         return sendKeyInfo;
+    }
+
+    public boolean isEidasEnabled() {
+        return eidasEnabled;
     }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/IdpStubsConfigurationFactory.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/IdpStubsConfigurationFactory.java
@@ -1,0 +1,43 @@
+package uk.gov.ida.stub.idp.domain.factories;
+
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.ConfigurationSourceProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.stub.idp.configuration.IdpStubsConfiguration;
+import uk.gov.ida.stub.idp.configuration.StubIdpConfiguration;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Optional;
+
+public class IdpStubsConfigurationFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IdpStubsConfigurationFactory.class);
+
+    private final StubIdpConfiguration stubIdpConfiguration;
+    private final ConfigurationFactory<IdpStubsConfiguration> configurationFactory;
+    private final ConfigurationSourceProvider configurationSourceProvider;
+
+    @Inject
+    public IdpStubsConfigurationFactory(StubIdpConfiguration stubIdpConfiguration, ConfigurationFactory<IdpStubsConfiguration> configurationFactory, ConfigurationSourceProvider configurationSourceProvider) {
+        this.stubIdpConfiguration = stubIdpConfiguration;
+        this.configurationFactory = configurationFactory;
+        this.configurationSourceProvider = configurationSourceProvider;
+    }
+
+    public Optional<IdpStubsConfiguration> tryBuildDefault() {
+        try {
+            return Optional.of(build(stubIdpConfiguration.getStubIdpsYmlFileLocation()));
+        } catch (IOException | ConfigurationException e) {
+            LOG.error("Error parsing configuration file, stubs remain unchanged", e);
+        }
+
+        return Optional.empty();
+    }
+
+    public IdpStubsConfiguration build(String stubIdpsYmlFileLocation) throws IOException, ConfigurationException {
+        return configurationFactory.build(configurationSourceProvider, stubIdpsYmlFileLocation);
+    }
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/StubCountryRepository.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/StubCountryRepository.java
@@ -1,23 +1,34 @@
 package uk.gov.ida.stub.idp.repositories;
 
+import uk.gov.ida.stub.idp.configuration.IdpStubsConfiguration;
+import uk.gov.ida.stub.idp.configuration.StubIdp;
+import uk.gov.ida.stub.idp.configuration.UserCredentials;
 import uk.gov.ida.stub.idp.domain.EidasScheme;
+import uk.gov.ida.stub.idp.domain.factories.IdpStubsConfigurationFactory;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.core.UriBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
 
 public class StubCountryRepository {
 
-    private final AllIdpsUserRepository allIdpsUserRepository;
-    private final String stubCountryMetadataUrl;
     public static final String STUB_COUNTRY_FRIENDLY_ID = EidasScheme.stub_country.getEidasSchemeName();
 
+    private final IdpStubsConfigurationFactory idpStubsConfigurationFactory;
+    private final AllIdpsUserRepository allIdpsUserRepository;
+    private final String stubCountryMetadataUrl;
+
     @Inject
-    public StubCountryRepository(AllIdpsUserRepository allIdpsUserRepository, @Named("StubCountryMetadataUrl") String stubCountryMetadataUrl) {
+    public StubCountryRepository(AllIdpsUserRepository allIdpsUserRepository, @Named("StubCountryMetadataUrl") String stubCountryMetadataUrl, IdpStubsConfigurationFactory idpStubsConfigurationFactory) {
         this.allIdpsUserRepository = allIdpsUserRepository;
         this.stubCountryMetadataUrl = stubCountryMetadataUrl;
+        this.idpStubsConfigurationFactory = idpStubsConfigurationFactory;
         allIdpsUserRepository.createHardcodedTestUsersForCountries(STUB_COUNTRY_FRIENDLY_ID, STUB_COUNTRY_FRIENDLY_ID);
     }
 
@@ -32,5 +43,22 @@ public class StubCountryRepository {
                 UriBuilder.fromUri(stubCountryMetadataUrl).build(eidasScheme.getEidasSchemeName()).toString(),
                 allIdpsUserRepository
         );
+    }
+
+    public List<UserCredentials> getUserCredentialsForFriendlyId(String friendlyId) {
+        final Optional<IdpStubsConfiguration> idpStubsConfiguration = idpStubsConfigurationFactory.tryBuildDefault();
+        if (!idpStubsConfiguration.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        final List<StubIdp> matchingCountries = idpStubsConfiguration.get().getStubCountries().stream()
+                .filter(c -> c.getFriendlyId().equals(friendlyId))
+                .collect(Collectors.toList());
+
+        if (matchingCountries.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return matchingCountries.get(0).getIdpUserCredentials();
     }
 }

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/listeners/StubIdpsFileListenerTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/listeners/StubIdpsFileListenerTest.java
@@ -19,6 +19,7 @@ import uk.gov.ida.stub.idp.configuration.SamlConfigurationImpl;
 import uk.gov.ida.stub.idp.configuration.StubIdp;
 import uk.gov.ida.stub.idp.configuration.StubIdpConfiguration;
 import uk.gov.ida.stub.idp.configuration.UserCredentials;
+import uk.gov.ida.stub.idp.domain.factories.IdpStubsConfigurationFactory;
 import uk.gov.ida.stub.idp.repositories.AllIdpsUserRepository;
 import uk.gov.ida.stub.idp.repositories.Idp;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
@@ -32,7 +33,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -68,8 +68,9 @@ public class StubIdpsFileListenerTest {
         Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         ConfigurationFactory<IdpStubsConfiguration> configurationFactory = new DefaultConfigurationFactoryFactory<IdpStubsConfiguration>().create(IdpStubsConfiguration.class, validator, Jackson.newObjectMapper(), "");
         ConfigurationSourceProvider configurationSourceProvider = path -> new FileInputStream(stubIdpConfiguration.getStubIdpsYmlFileLocation());
+        IdpStubsConfigurationFactory idpStubsConfigurationFactory = new IdpStubsConfigurationFactory(stubIdpConfiguration, configurationFactory, configurationSourceProvider);
         AllIdpsUserRepository allIdpsUserRepository = new AllIdpsUserRepository(mock(JDBIUserRepository.class));
-        idpStubsRepository = new IdpStubsRepository(allIdpsUserRepository, stubIdpConfiguration,  configurationFactory, configurationSourceProvider) {
+        idpStubsRepository = new IdpStubsRepository(allIdpsUserRepository, stubIdpConfiguration,  idpStubsConfigurationFactory) {
             @Override
             public void load(String yamlFile) {
                 super.load(yamlFile);


### PR DESCRIPTION
The `stub-idp.yml` config file now includes `stub-country` so we can access it via the API to query and create users. However, this means that it's treated as an IDP and therefore eIDAS journeys on non-prod environments are not working. This change makes sure the code treats countries and IDPs separately and that it doesn't create eIDAS users in IDP format, which is what made Stub IDP broken.

Summary of changes:
  - Add a class to easily access the `stub-idps.yml` config file which contains the credentials for all stub IDPs and stub-country
  - Separate credentials handling into `IdpStubsRepository` for IDPs and `StubCountryRepository` for countries
  - Make the auth filter aware of the difference
  - Make the new class injectable