### PR TITLE
HUB-296: Add acceptance tests for Single IDP journey

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/services/ServiceListService.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/services/ServiceListService.java
@@ -40,7 +40,7 @@ public class ServiceListService {
             List<Service> services = jsonClient.get(singleIdpConfiguration.getServiceListUri(), new GenericType<List<Service>>() {});
 
             return services;
-        } catch (ProcessingException ex) {
+        } catch (RuntimeException ex) {
             LOG.error(MessageFormat.format("Error getting service list from {0}", singleIdpConfiguration.getServiceListUri().toString()), ex);
         }
         return new ArrayList<Service>() {};

--- a/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/singleIdpPromptPage.ftl
+++ b/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/singleIdpPromptPage.ftl
@@ -29,3 +29,12 @@
         </div>
     </#list>
 </div>
+<hr>
+<small>Manually initiate the journey</small>
+<form method="post" action="${verifySubmissionUrl}">
+    <input name="serviceId" placeholder="serviceId" />
+    <input name="idpEntityId" placeholder="idpEntityId" />
+    <input name="singleIdpJourneyIdentifier" value="${uniqueId}" />
+    <input type="submit" value="Initiate Single IDP journey" />
+</form>
+


### PR DESCRIPTION
In order for us to test the single IDP journey in staging and integration
we need to initiate the single IDP journey manually (via form). This is
due to the fact that Stub IDP is not able to talk to Frontend in these
environments.
- changed the exception type when the NETWORK_ERROR occurs, the app doesn't crash
- added a POST form to the prompt page for the tests to use