### PR TITLE
BAU: Fix Database Migration Runner H2/Postgres switch

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/migrations/DatabaseMigrationRunner.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/jdbc/migrations/DatabaseMigrationRunner.java
@@ -15,6 +15,6 @@ public class DatabaseMigrationRunner {
     }
 
     private String getDBSpecificMigration(String dbUrl) {
-        return dbUrl.contains("h2") ? "classpath:db.migrations.h2" : "classpath:db.migrations.postgres";
+        return dbUrl.contains(":h2:") ? "classpath:db.migrations.h2" : "classpath:db.migrations.postgres";
     }
 }


### PR DESCRIPTION
Currently Encoded password contains the letters "h2" which is causing database migration to pick up wrong versions of the script.
This is a quick fix. Long term fix required. 