### PR TITLE
BAU disable robots and fix bug in debug page

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/views/DebugPageView.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/views/DebugPageView.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.stub.idp.views;
 
+import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.stub.idp.domain.IdpHint;
 import uk.gov.ida.stub.idp.domain.IdpLanguageHint;
 import uk.gov.ida.stub.idp.repositories.IdpSession;
@@ -45,6 +46,10 @@ public class DebugPageView extends IdpPageView {
     public List<String> getAuthnContexts() {
         return session.getIdaAuthnRequestFromHub().getLevelsOfAssurance().stream()
             .map(Enum::name).collect(Collectors.toList());
+    }
+
+    public IdaAuthnRequestFromHub getIdaAuthnRequestFromHub() {
+        return session.getIdaAuthnRequestFromHub();
     }
 
     public String getRelayState() {

--- a/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/debugPage.ftl
+++ b/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/debugPage.ftl
@@ -16,78 +16,86 @@
 
     <h2>System information</h2>
 
-    <p id="registration">
-        <#if registration.isPresent() >
-            "registration" hint is "${registration.get()?string}"
-        <#else>
-            "registration" hint not received
-        </#if>
-    </p>
-
-    <p id="language-hint">
-        <#if languageHint?has_content>
-            The language hint was set to "${languageHint}".
-        <#else>
-            No language hint was set.
-        </#if>
-    </p>
-
-    <#list knownHints>
-      <p>The following known hints were sent from the GOV.UK Verify hub:</p>
-      <ul class="known-hints">
-        <#items as hint>
-        <li>${hint}</li>
-        </#items>
-      </ul>
-    </#list>
-
-    <#list unknownHints>
-      <p>The following unknown hints were sent:</p>
-      <ul class="unknown-hints">
-        <#items as hint>
-        <li>${hint}</li>
-        </#items>
-      </ul>
-    </#list>
-
-    <#if !knownHints?has_content && !unknownHints?has_content>
-      <p>No answer hints were sent.</p>
-    </#if>
-
-    <p id="authn-request-comparision-type">
-        AuthnRequest comparison type is "${comparisonType}".
-    </p>
-
-    <#list authnContexts>
-        <p>The following AuthnContexts were sent:</p>
-        <ul class="authn-contexts">
-        <#items as authnContext>
-        <li>${authnContext}</li>
-        </#items>
-        </ul>
-    </#list>
-
-    <p id="authn-request-issuer">
-        Request issuer is "${authnRequestIssuer}".
-    </p>
-
-    <p id="saml-request-id">
-        Request Id is "${samlRequestId}".
-    </p>
-
     <p id="idp-session-id">
         Stub-IDP sessionId is "${sessionId}".
     </p>
 
-    <p id="relay-state">
-        Relay state is "${relayState}".
-    </p>
 
-    <p id="single-idp-journey-id">
-        <#if singleIdpJourneyId?has_content>
-            This a single IDP journey and the single IDP UUID is "${singleIdpJourneyId}".
-        <#else>
-            This is not a single IDP journey.
+
+    <#if idaAuthnRequestFromHub??>
+        <p id="registration">
+            <#if registration.isPresent() >
+                "registration" hint is "${registration.get()?string}"
+            <#else>
+                "registration" hint not received
+            </#if>
+        </p>
+
+        <p id="language-hint">
+            <#if languageHint?has_content>
+                The language hint was set to "${languageHint}".
+            <#else>
+                No language hint was set.
+            </#if>
+        </p>
+
+        <#if knownHints??>
+            <#list knownHints>
+              <p>The following known hints were sent from the GOV.UK Verify hub:</p>
+              <ul class="known-hints">
+                <#items as hint>
+                <li>${hint}</li>
+                </#items>
+              </ul>
+            </#list>
         </#if>
-    </p>
+
+        <#if unknownHints??>
+            <#list unknownHints>
+              <p>The following unknown hints were sent:</p>
+              <ul class="unknown-hints">
+                <#items as hint>
+                <li>${hint}</li>
+                </#items>
+              </ul>
+            </#list>
+        </#if>
+
+        <#if !knownHints?has_content && !unknownHints?has_content>
+          <p>No answer hints were sent.</p>
+        </#if>
+
+        <p id="authn-request-comparision-type">
+            AuthnRequest comparison type is "${comparisonType}".
+        </p>
+
+        <#list authnContexts>
+            <p>The following AuthnContexts were sent:</p>
+            <ul class="authn-contexts">
+            <#items as authnContext>
+            <li>${authnContext}</li>
+            </#items>
+            </ul>
+        </#list>
+
+        <p id="authn-request-issuer">
+            Request issuer is "${authnRequestIssuer}".
+        </p>
+
+        <p id="saml-request-id">
+            Request Id is "${samlRequestId}".
+        </p>
+
+        <p id="relay-state">
+            Relay state is "${relayState}".
+        </p>
+
+        <p id="single-idp-journey-id">
+            <#if singleIdpJourneyId?has_content>
+                This a single IDP journey and the single IDP UUID is "${singleIdpJourneyId}".
+            <#else>
+                This is not a single IDP journey.
+            </#if>
+        </p>
+    </#if>
 </div>

--- a/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/idpPage.ftl
+++ b/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/idpPage.ftl
@@ -5,6 +5,7 @@
     <title>${pageTitle}</title>
     <meta charset="utf-8"/>
     <meta content="width=device-width,initial-scale=1.0" name="viewport"/>
+    <meta name="robots" content="noindex">
     <link href="/assets/styles/application_auth.css" media="all"
           rel="stylesheet" type="text/css"/>
     <link href="/assets/styles/application_auth_extensions.css" media="all"


### PR DESCRIPTION
Add robot-repellent meta tag to idpPageTemplate.ftl.
Restrict output of debug page to values that exist in the session.