### PR TITLE
bau - Dont allow failures on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ jdk:
   - openjdk11
 matrix:
   fast_finish: true
-  allow_failures:
-  - jdk: openjdk10
-  - jdk: openjdk11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
- Stub-idp builds successfully on jdk10 and jdk11 so no need to allow failures. 