### PR TITLE
bau - Stop building for java10 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
 jdk:
   - oraclejdk8
   - openjdk8
-  - openjdk10
   - openjdk11
 matrix:
   fast_finish: true


### PR DESCRIPTION
- Save time by not building on java10 in travis as we can now build successfully using java11