### PR TITLE
HUB-51_update_dropwizard_to_1.3.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
 def dependencyVersions = [
         opensaml              : "$opensaml_version",
         ida_utils             : '2.0.0-350',
-        dropwizard            : '1.1.4',
+        dropwizard            : '1.3.8',
         ida_dev_pki           : '1.1.0-34',
         saml_libs             : "$opensaml_version-157",
         ida_test_utils        : '2.0.0-43',

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpApplication.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpApplication.java
@@ -106,7 +106,7 @@ public class StubIdpApplication extends Application<StubIdpConfiguration> {
             @Override
             public Map<String, Map<String, String>> getViewConfiguration(StubIdpConfiguration config) {
                 // beware: this is to force enable escaping of unsanitised user input
-                return ImmutableMap.of(new FreemarkerViewRenderer().getSuffix(),
+                return ImmutableMap.of(new FreemarkerViewRenderer().getConfigurationKey(),
                     ImmutableMap.of(
                         "output_format", "HTMLOutputFormat"
                     ));


### PR DESCRIPTION
Update DropWizard to latest release.

Change .getSuffix() to .getConfigureationKey() on FreemarkerViewRenderer used when configuring the ViewBundle.