### PR TITLE
BAU: Don't set To dates for default users

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/HardCodedTestUserList.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/repositories/HardCodedTestUserList.java
@@ -347,8 +347,6 @@ public final class HardCodedTestUserList {
             return null;
         }
 
-        DateTime from = DateTime.now();
-
-        return new MatchingDatasetValue<>(value, from, from.plusYears(1), true);
+        return new MatchingDatasetValue<>(value, DateTime.now().minusDays(1), null, true);
     }
 }


### PR DESCRIPTION
- If you only have one e.g. FirstName, you expect it to be current (i.e.
  it has no "To" date)
- The MSA only adds current attributes to the assertions when doing user
  account creation so when setting a "To" date, none of those attributes
are included

Co-authored-by: Christopher Wynne <christopher.wynne@digital.cabinet-office.gov.uk>