### PR TITLE
BAU: Upgrade PaaS stack to cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
   - name: ida-stub-idp
+    stack: cflinuxfs3
     memory: 1G
     buildpack: java_buildpack
     env:


### PR DESCRIPTION
PaaS are removing the stack cflinuxfs2 and require all apps to be
upgraded to cflinuxfs3.