### PR TITLE
BAU: Update libs and build Stub IDP on Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: java
 env:
   - VERIFY_USE_PUBLIC_BINARIES=true
 jdk:
-  - oraclejdk8
-  - openjdk8
   - openjdk11
 matrix:
   fast_finish: true

--- a/build.gradle
+++ b/build.gradle
@@ -19,18 +19,18 @@ apply plugin: 'java'
 apply plugin: 'com.github.ben-manes.versions'
 
 ext {
-  opensaml_version = '3.3.0'
+  opensaml_version = '3.4.2'
   build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
 def dependencyVersions = [
         opensaml              : "$opensaml_version",
-        ida_utils             : '2.0.0-350',
+        ida_utils             : '2.0.0-368',
         dropwizard            : '1.3.8',
-        ida_dev_pki           : '1.1.0-34',
-        saml_libs             : "$opensaml_version-157",
-        ida_test_utils        : '2.0.0-43',
-        hub_saml              : "$opensaml_version-15582",
+        ida_dev_pki           : '1.1.0-37',
+        saml_libs             : "$opensaml_version-203",
+        ida_test_utils        : '2.0.0-46',
+        hub_saml              : "$opensaml_version-15757",
         hk2_version           : '2.5.0-b05'
 ]
 
@@ -84,12 +84,9 @@ subprojects {
                 "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
                 "org.postgresql:postgresql:42.1.4",
                 "uk.gov.ida:common-utils:$dependencyVersions.ida_utils",
-                "uk.gov.ida:saml-extensions:$dependencyVersions.saml_libs",
+                "uk.gov.ida:saml-lib:$dependencyVersions.saml_libs",
                 "uk.gov.ida:rest-utils:$dependencyVersions.ida_utils",
-                "uk.gov.ida:saml-metadata-bindings:$dependencyVersions.saml_libs",
-                "uk.gov.ida:saml-security:$dependencyVersions.saml_libs",
                 "uk.gov.ida:security-utils:$dependencyVersions.ida_utils",
-                "uk.gov.ida:saml-utils:$dependencyVersions.saml_libs",
                 "javax.activation:javax.activation-api:1.2.0",
                 "javax.xml.bind:jaxb-api:2.2.3",
                 project(':stub-idp-saml')
@@ -100,7 +97,7 @@ subprojects {
 
         stub_idp_test "io.dropwizard:dropwizard-testing:$dependencyVersions.dropwizard",
                 "uk.gov.ida:ida-dev-pki:$dependencyVersions.ida_dev_pki",
-                "uk.gov.ida:saml-metadata-bindings-test:$dependencyVersions.saml_libs",
+                "uk.gov.ida:saml-test:$dependencyVersions.saml_libs",
                 "uk.gov.ida:common-test-utils:$dependencyVersions.ida_test_utils",
                 "uk.gov.ida:hub-saml:$dependencyVersions.hub_saml",
                 "uk.gov.ida:hub-saml-test-utils:$dependencyVersions.hub_saml",
@@ -108,7 +105,7 @@ subprojects {
                 'commons-codec:commons-codec:1.10',
                 project(':stub-idp-saml-test')
 
-        stub_idp_saml  "uk.gov.ida:saml-utils:$dependencyVersions.saml_libs",
+        stub_idp_saml  "uk.gov.ida:saml-lib:$dependencyVersions.saml_libs",
                 "org.opensaml:opensaml-core:$dependencyVersions.opensaml",
                 'joda-time:joda-time:2.9',
                 'javax.inject:javax.inject:1',
@@ -118,6 +115,8 @@ subprojects {
                 'commons-lang:commons-lang:2.6'
 
         stub_idp_saml_test 'commons-codec:commons-codec:1.10',
+                "uk.gov.ida:ida-dev-pki:$dependencyVersions.ida_dev_pki",
+                "uk.gov.ida:saml-test:$dependencyVersions.saml_libs",
                 "uk.gov.ida:common-utils:$dependencyVersions.ida_utils",
                 'org.assertj:assertj-joda-time:1.1.0'
     }

--- a/stub-idp/src/integration-test/java/uk/gov/ida/apprule/HomePageIntegrationTest.java
+++ b/stub-idp/src/integration-test/java/uk/gov/ida/apprule/HomePageIntegrationTest.java
@@ -6,7 +6,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.apprule.steps.FormBuilder;
 import uk.gov.ida.apprule.steps.PreRegistrationSteps;
 import uk.gov.ida.apprule.support.StubIdpAppRule;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/StubIdpModuleTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/StubIdpModuleTest.java
@@ -3,7 +3,7 @@ package uk.gov.ida.stub.idp;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.saml.core.test.TestCertificateStrings;
 import uk.gov.ida.stub.idp.configuration.SigningKeyPairConfiguration;
 import uk.gov.ida.stub.idp.configuration.StubIdpConfiguration;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/builders/CountryMetadataBuilderTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/builders/CountryMetadataBuilderTest.java
@@ -16,7 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.metadata.ArtifactResolutionService;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/cookies/CookieFactoryTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/cookies/CookieFactoryTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.common.shared.configuration.SecureCookieConfiguration;
 import uk.gov.ida.common.shared.security.HmacDigest;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/cookies/HmacValidatorTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/cookies/HmacValidatorTest.java
@@ -3,7 +3,7 @@ package uk.gov.ida.stub.idp.cookies;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.common.shared.security.HmacDigest;
 

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/filters/SecurityHeadersFilterTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/filters/SecurityHeadersFilterTest.java
@@ -3,7 +3,7 @@ package uk.gov.ida.stub.idp.filters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/filters/SessionCookieValueMustExistAsASessionFilterTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/filters/SessionCookieValueMustExistAsASessionFilterTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.stub.idp.cookies.HmacValidator;
 import uk.gov.ida.stub.idp.exceptions.InvalidSecureCookieException;
@@ -21,7 +21,6 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.NewCookie;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -29,7 +28,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ida.stub.idp.cookies.CookieNames.SECURE_COOKIE_NAME;
 import static uk.gov.ida.stub.idp.cookies.CookieNames.SESSION_COOKIE_NAME;
 import static uk.gov.ida.stub.idp.filters.SessionCookieValueMustExistAsASessionFilter.NO_CURRENT_SESSION_COOKIE_VALUE;
-
 
 @RunWith(MockitoJUnitRunner.class)
 public class SessionCookieValueMustExistAsASessionFilterTest {
@@ -49,28 +47,28 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         JerseyGuiceUtils.reset();
     }
 
-    @Test (expected = SessionIdCookieNotFoundException.class)
+    @Test(expected = SessionIdCookieNotFoundException.class)
     public void shouldReturnNullWhenCheckingNotRequiredButNoCookies() {
         Map<String, Cookie> cookies = ImmutableMap.of();
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
-    @Test (expected = SecureCookieNotFoundException.class)
+    @Test(expected = SecureCookieNotFoundException.class)
     public void shouldReturnNullWhenCheckingNotRequiredButSecureCookie() {
         Map<String, Cookie> cookies = ImmutableMap.of(SESSION_COOKIE_NAME, new NewCookie(SESSION_COOKIE_NAME, "some-session-id"));
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
-    @Test (expected = InvalidSecureCookieException.class)
+    @Test(expected = InvalidSecureCookieException.class)
     public void shouldReturnNullWhenCheckingNotRequiredButSessionCookieIsSetToNoCurrentValue() {
         Map<String, Cookie> cookies = ImmutableMap.of(SESSION_COOKIE_NAME, new NewCookie(SESSION_COOKIE_NAME, "some-session-id"), SECURE_COOKIE_NAME, new NewCookie(SECURE_COOKIE_NAME, NO_CURRENT_SESSION_COOKIE_VALUE));
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
 
-    @Test (expected = InvalidSecureCookieException.class)
+    @Test(expected = InvalidSecureCookieException.class)
     public void shouldReturnNullWhenCheckingNotRequiredButSessionCookieAndSecureCookieDontMatchUp() {
         SessionId sessionId = SessionId.createNewSessionId();
         Map<String, Cookie> cookies = ImmutableMap.of(SESSION_COOKIE_NAME, new NewCookie(SESSION_COOKIE_NAME, sessionId.toString()), SECURE_COOKIE_NAME, new NewCookie(SECURE_COOKIE_NAME, "secure-cookie"));
@@ -159,7 +157,7 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         }
     }
 
-    @Test (expected = SessionNotFoundException.class)
+    @Test(expected = SessionNotFoundException.class)
     public void shouldThrowNotFoundIfSessionNotActive() {
         SessionId sessionId = SessionId.createNewSessionId();
         Map<String, Cookie> cookies = ImmutableMap.of(
@@ -168,10 +166,8 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
         );
         when(containerRequestContext.getCookies()).thenReturn(cookies);
         when(hmacValidator.validateHMACSHA256("secure-cookie", sessionId.getSessionId())).thenReturn(true);
-        when(idpSessionRepository.get(sessionId)).thenReturn(Optional.empty());
         new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, isSecureCookieEnabled).filter(containerRequestContext);
     }
-
 
     @Test
     public void shouldIgnoreSecureCookieIfSecureCookiesNotEnabled() {
@@ -181,7 +177,6 @@ public class SessionCookieValueMustExistAsASessionFilterTest {
                 SECURE_COOKIE_NAME, new NewCookie(SECURE_COOKIE_NAME, "secure-cookies")
         );
         when(containerRequestContext.getCookies()).thenReturn(cookies);
-        when(hmacValidator.validateHMACSHA256("secure-cookies", sessionId.getSessionId())).thenReturn(false);
         when(idpSessionRepository.containsSession(sessionId)).thenReturn(true);
         new SessionCookieValueMustExistAsASessionFilter(idpSessionRepository, eidasSessionRepository, hmacValidator, false).filter(containerRequestContext);
     }

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/ConsentResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/ConsentResourceTest.java
@@ -8,7 +8,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.saml.core.domain.AddressFactory;
 import uk.gov.ida.saml.core.domain.AuthnContext;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/DebugPageResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/DebugPageResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.stub.idp.repositories.Idp;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasConsentResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasConsentResourceTest.java
@@ -7,7 +7,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
 import uk.gov.ida.stub.idp.domain.EidasScheme;
@@ -60,7 +60,7 @@ public class EidasConsentResourceTest {
     private StubCountry stubCountry;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         resource = new EidasConsentResource(sessionRepository, successAuthnResponseService, successAuthnResponseService, samlResponseRedirectViewFactory, stubCountryRepository);
 
         EidasAuthnRequest eidasAuthnRequest = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
@@ -72,7 +72,7 @@ public class EidasConsentResourceTest {
     }
 
     @Test
-    public void getShouldReturnASuccessfulResponseWhenSessionIsValid(){
+    public void getShouldReturnASuccessfulResponseWhenSessionIsValid() {
         when(stubCountryRepository.getStubCountryWithFriendlyId(EidasScheme.fromString(SCHEME_NAME).get())).thenReturn(stubCountry);
 
         final Response response = resource.get(SCHEME_NAME, SESSION_ID);
@@ -86,7 +86,7 @@ public class EidasConsentResourceTest {
         when(successAuthnResponseService.getSuccessResponse(session, SCHEME_NAME)).thenReturn(samlResponse);
         when(samlResponseRedirectViewFactory.sendSamlMessage(samlResponse)).thenReturn(Response.ok().build());
 
-        final Response response = resource.consent(SCHEME_NAME, "rsasha256","submit", SESSION_ID);
+        final Response response = resource.consent(SCHEME_NAME, "rsasha256", "submit", SESSION_ID);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
@@ -97,7 +97,7 @@ public class EidasConsentResourceTest {
         when(successAuthnResponseService.getSuccessResponse(session, SCHEME_NAME)).thenReturn(samlResponse);
         when(samlResponseRedirectViewFactory.sendSamlMessage(samlResponse)).thenReturn(Response.ok().build());
 
-        final Response response = resource.consent(SCHEME_NAME, "rsassa-pss","submit", SESSION_ID);
+        final Response response = resource.consent(SCHEME_NAME, "rsassa-pss", "submit", SESSION_ID);
 
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
     }
@@ -105,16 +105,12 @@ public class EidasConsentResourceTest {
     @Test(expected = InvalidSigningAlgorithmException.class)
     public void postShouldThrowAnExceptionWhenAnInvalidSigningAlgorithmIsUsed() {
         SamlResponseFromValue<org.opensaml.saml.saml2.core.Response> samlResponse = new SamlResponseFromValue<>(null, (r) -> null, null, null);
-        when(successAuthnResponseService.getSuccessResponse(session, SCHEME_NAME)).thenReturn(samlResponse);
-        when(samlResponseRedirectViewFactory.sendSamlMessage(samlResponse)).thenReturn(Response.ok().build());
 
-        resource.consent(SCHEME_NAME, "rsa-sha384","submit", SESSION_ID);
+        resource.consent(SCHEME_NAME, "rsa-sha384", "submit", SESSION_ID);
     }
-
 
     @Test(expected = GenericStubIdpException.class)
-    public void shouldThrowAGenericStubIdpExceptionWhenSessionIsEmpty(){
+    public void shouldThrowAGenericStubIdpExceptionWhenSessionIsEmpty() {
         resource.get(SCHEME_NAME, null);
     }
-
 }

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasLoginPageResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasLoginPageResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.stub.idp.Urls;
 import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasProxyNodeServiceMetadataResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasProxyNodeServiceMetadataResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
@@ -27,7 +27,7 @@ import java.text.MessageFormat;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasProxyNodeServiceMetadataResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasProxyNodeServiceMetadataResourceTest.java
@@ -27,7 +27,7 @@ import java.text.MessageFormat;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.ArgumentMatchers.eq;;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasRegistrationPageResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/EidasRegistrationPageResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.stub.idp.domain.EidasAuthnRequest;
 import uk.gov.ida.stub.idp.domain.EidasScheme;
@@ -30,8 +30,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.core.domain.AuthnContext.LEVEL_2;
@@ -82,8 +82,8 @@ public class EidasRegistrationPageResourceTest {
     }
 
     @Test
-    public void shouldHaveStatusAuthnCancelledResponseWhenUserCancels(){
-        when(nonSuccessAuthnResponseService.generateAuthnCancel(anyString(), anyString(), eq(RELAY_STATE))).thenReturn(new SamlResponseFromValue<>("saml", Function.identity(), RELAY_STATE, URI.create("uri")));
+    public void shouldHaveStatusAuthnCancelledResponseWhenUserCancels() {
+        when(nonSuccessAuthnResponseService.generateAuthnCancel(any(String.class), any(String.class), eq(RELAY_STATE))).thenReturn(new SamlResponseFromValue<>("saml", Function.identity(), RELAY_STATE, URI.create("uri")));
 
         resource.post(STUB_COUNTRY, null, null, null, null, null, null, null, null, Cancel, SESSION_ID);
 
@@ -96,8 +96,6 @@ public class EidasRegistrationPageResourceTest {
         final Response response = resource.post(STUB_COUNTRY, "bob", "", "jones", "", "2000-01-01", "username", "password", LEVEL_2, Register, SESSION_ID);
 
         assertThat(response.getStatus()).isEqualTo(303);
-        verify(stubCountryService).createAndAttachIdpUserToSession(eq(EidasScheme.fromString(STUB_COUNTRY).get()), anyString(), anyString(), eq(eidasSession), anyString(), anyString(), anyString(), anyString(), anyString(), eq(LEVEL_2));
+        verify(stubCountryService).createAndAttachIdpUserToSession(eq(EidasScheme.fromString(STUB_COUNTRY).get()), any(String.class), any(String.class), eq(eidasSession), any(String.class), any(String.class), any(String.class), any(String.class), any(String.class), eq(LEVEL_2));
     }
-
-
 }

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/RegistrationPageResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/RegistrationPageResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
 import uk.gov.ida.stub.idp.cookies.CookieFactory;
@@ -31,8 +31,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.saml.core.domain.AuthnContext.LEVEL_2;
@@ -88,8 +88,8 @@ public class RegistrationPageResourceTest {
     }
 
     @Test
-    public void shouldHaveStatusAuthnCancelledResponseWhenUserCancels(){
-        when(nonSuccessAuthnResponseService.generateAuthnCancel(anyString(), anyString(), eq(RELAY_STATE))).thenReturn(new SamlResponseFromValue<>("saml", Function.identity(), RELAY_STATE, URI.create("uri")));
+    public void shouldHaveStatusAuthnCancelledResponseWhenUserCancels() {
+        when(nonSuccessAuthnResponseService.generateAuthnCancel(any(String.class), any(String.class), eq(RELAY_STATE))).thenReturn(new SamlResponseFromValue<>("saml", Function.identity(), RELAY_STATE, URI.create("uri")));
 
         resource.post(IDP_NAME, null, null, null, null, null, null, null, null, null, null, Cancel, SESSION_ID);
 
@@ -105,7 +105,7 @@ public class RegistrationPageResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(303);
         assertThat(response.getLocation().toString()).contains("consent");
-        verify(idpUserService).createAndAttachIdpUserToSession(eq(IDP_NAME), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq(LEVEL_2), anyString(), anyString(), anyString(), eq(SESSION_ID));
+        verify(idpUserService).createAndAttachIdpUserToSession(eq(IDP_NAME), any(String.class), any(String.class), any(String.class), any(String.class), any(String.class), any(String.class), eq(LEVEL_2), any(String.class), any(String.class), any(String.class), eq(SESSION_ID));
     }
 
     @Test
@@ -117,7 +117,6 @@ public class RegistrationPageResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(303);
         assertThat(response.getLocation().toString()).contains("start-prompt");
-        verify(idpUserService).createAndAttachIdpUserToSession(eq(IDP_NAME), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq(LEVEL_2), anyString(), anyString(), anyString(), eq(SESSION_ID));
+        verify(idpUserService).createAndAttachIdpUserToSession(eq(IDP_NAME), any(String.class), any(String.class), any(String.class), any(String.class), any(String.class), any(String.class), eq(LEVEL_2), any(String.class), any(String.class), any(String.class), eq(SESSION_ID));
     }
-
 }

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/SingleIdpPromptResourceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/resources/SingleIdpPromptResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.saml.core.test.TestEntityIds;
 import uk.gov.ida.stub.idp.configuration.SingleIdpConfiguration;
 import uk.gov.ida.stub.idp.domain.Service;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/EidasAuthnResponseServiceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/EidasAuthnResponseServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.StatusCode;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/IdpUserServiceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/IdpUserServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;
@@ -23,12 +23,11 @@ import uk.gov.ida.stub.idp.repositories.IdpSession;
 import uk.gov.ida.stub.idp.repositories.IdpSessionRepository;
 import uk.gov.ida.stub.idp.repositories.IdpStubsRepository;
 
-import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -80,12 +79,10 @@ public class IdpUserServiceTest {
 
     @Test
     public void shouldHaveStatusSuccessResponseWhenUserRegisters() throws InvalidSessionIdException, IncompleteRegistrationException, InvalidDateException, UsernameAlreadyTakenException, InvalidUsernameOrPasswordException {
-        IdpSession session = new IdpSession(SessionId.createNewSessionId(), idaAuthnRequestFromHubOptional, "test-relay-state", Collections.emptyList(), Collections.emptyList(), Optional.empty(), Optional.empty(), Optional.empty());
         when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new IdpSession(SESSION_ID, idaAuthnRequestFromHubOptional, RELAY_STATE, null, null, null, null, null)));
         when(idpStubsRepository.getIdpWithFriendlyId(IDP_NAME)).thenReturn(idp);
         when(idp.userExists(USERNAME)).thenReturn(false);
         when(idp.createUser(any(), any(), any(), any(), any(), any(), any(), eq(USERNAME), eq(PASSWORD), any())).thenReturn(mock(DatabaseIdpUser.class));
-        when(sessionRepository.createSession(session)).thenReturn(SESSION_ID);
 
         idpUserService.createAndAttachIdpUserToSession(IDP_NAME, "bob", "jones", "address line 1", "address line 2", "address town", "address postcode", AuthnContext.LEVEL_2, "2000-01-01", USERNAME, "password", SESSION_ID);
 

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/NonSuccessAuthnResponseServiceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/NonSuccessAuthnResponseServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.saml.hub.domain.IdaAuthnRequestFromHub;

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/ServiceListServiceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/ServiceListServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.stub.idp.configuration.SingleIdpConfiguration;
 import uk.gov.ida.stub.idp.domain.Service;
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/StubCountryServiceTest.java
+++ b/stub-idp/src/test/java/uk/gov/ida/stub/idp/services/StubCountryServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.ida.common.SessionId;
 import uk.gov.ida.saml.core.domain.AuthnContext;
 import uk.gov.ida.stub.idp.domain.DatabaseEidasUser;
@@ -28,7 +28,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class StubCountryServiceTest {
 
-    private final String RELAY_STATE = "relayState";
     private static final EidasScheme EIDAS_SCHEME = EidasScheme.stub_country;
     private static final String PASSWORD = "password";
     private static final String USERNAME = "username";
@@ -49,7 +48,7 @@ public class StubCountryServiceTest {
     private EidasSession session;
 
     private EidasAuthnRequest eidasAuthnRequest;
-    
+
     @Mock
     private SessionRepository<EidasSession> sessionRepository;
 
@@ -60,7 +59,7 @@ public class StubCountryServiceTest {
     private StubCountry stubCountry;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         when(stubCountryRepository.getStubCountryWithFriendlyId(EIDAS_SCHEME)).thenReturn(stubCountry);
         stubCountryService = new StubCountryService(stubCountryRepository, sessionRepository);
         eidasAuthnRequest = new EidasAuthnRequest("request-id", "issuer", "destination", "loa", Collections.emptyList());
@@ -88,7 +87,6 @@ public class StubCountryServiceTest {
     @Test
     public void shouldHaveStatusSuccessResponseWhenUserRegisters() throws InvalidSessionIdException, IncompleteRegistrationException, InvalidDateException, UsernameAlreadyTakenException, InvalidUsernameOrPasswordException {
         EidasSession session = new EidasSession(SESSION_ID, eidasAuthnRequest, "test-relay-state", Collections.emptyList(), Collections.emptyList(), Optional.empty(), Optional.empty());
-        when(sessionRepository.get(SESSION_ID)).thenReturn(Optional.ofNullable(new EidasSession(SESSION_ID, eidasAuthnRequest, RELAY_STATE, null, null, null, null)));
         when(stubCountryRepository.getStubCountryWithFriendlyId(EIDAS_SCHEME)).thenReturn(stubCountry);
         when(stubCountry.createUser(eq(USERNAME), eq(PASSWORD), any(), any(), any(), any(), any(), any())).thenReturn(newUser().get());
 
@@ -105,4 +103,3 @@ public class StubCountryServiceTest {
         return (value == null) ? null : new MatchingDatasetValue<>(value, null, null, true);
     }
 }
-


### PR DESCRIPTION
This is to enable deploying stub IDP from Concourse