### PR TITLE
BAU Upload libs to Artifactory in Concourse pipleline

### DIFF
--- a/stub-idp-saml-test/build.gradle
+++ b/stub-idp-saml-test/build.gradle
@@ -6,7 +6,11 @@ apply plugin: 'java'
 publishing {
     repositories {
         maven {
-            url "/srv/maven" // change to point to your repo, e.g. http://my.org/repo
+            credentials {
+                username "${System.env.ARTIUSER}"
+                password "${System.env.ARTIPASSWORD}"
+            }
+            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
         }
     }
 

--- a/stub-idp-saml/build.gradle
+++ b/stub-idp-saml/build.gradle
@@ -6,7 +6,11 @@ apply plugin: 'java'
 publishing {
     repositories {
         maven {
-            url "/srv/maven" // change to point to your repo, e.g. http://my.org/repo
+            credentials {
+                username "${System.env.ARTIUSER}"
+                password "${System.env.ARTIPASSWORD}"
+            }
+            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
         }
     }
 


### PR DESCRIPTION
- stub-idp-saml and stub-idp-saml-test libs to be built and uploaded to Artifactory in the build-libraries Concourse pipeline.
- This change provides the config to access Artifactory.