### PR TITLE
EID-1677 send unsigned assertions from stub-country

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/StubIdpModule.java
@@ -340,7 +340,8 @@ public class StubIdpModule extends AbstractModule {
     public EidasResponseTransformerProvider getECDSAEidasResponseTransfomerProvider(
             @Named(StubIdpModule.HUB_CONNECTOR_ENCRYPTION_KEY_STORE) Optional<EncryptionKeyStore> encryptionKeyStore,
             @Named(COUNTRY_SIGNING_KEY_STORE) IdaKeyStore keyStore,
-            EntityToEncryptForLocator entityToEncryptForLocator) {
+            EntityToEncryptForLocator entityToEncryptForLocator,
+            StubIdpConfiguration stubIdpConfiguration) {
         return new EidasResponseTransformerProvider(
                 new CoreTransformersFactory(),
                 encryptionKeyStore.orElse(null),
@@ -370,7 +371,8 @@ public class StubIdpModule extends AbstractModule {
     public EidasResponseTransformerProvider getEidasResponseTransformerProvider(
         @Named(StubIdpModule.HUB_CONNECTOR_ENCRYPTION_KEY_STORE) Optional<EncryptionKeyStore> encryptionKeyStore,
         @Named(COUNTRY_SIGNING_KEY_STORE) IdaKeyStore keyStore,
-        EntityToEncryptForLocator entityToEncryptForLocator) {
+        EntityToEncryptForLocator entityToEncryptForLocator,
+        StubIdpConfiguration stubIdpConfiguration) {
         return new EidasResponseTransformerProvider(
             new CoreTransformersFactory(),
             encryptionKeyStore.orElse(null),

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/EidasScheme.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/EidasScheme.java
@@ -6,50 +6,54 @@ import java.util.Optional;
  * This can't be used to read path params directly as we are using params with dashes
  */
 public enum EidasScheme {
-    stub_country("stub-country"),
-    stub_cef_reference("stub-cef-reference"),
+    stub_country("stub-country", true),
+    stub_country_unsigned_assertions("stub-country-unsigned-assertions", false),
+    stub_cef_reference("stub-cef-reference", true),
 
-    austria("austria"),
-    belgium("belgium"),
-    bulgaria("bulgaria"),
-    croatia("croatia"),
-    cyprus("cyprus"),
-    czech_republic("czech-republic"),
-    denmark("denmark"),
-    estonia("estonia"),
-    finland("finland"),
-    france("france"),
-    germany("germany"),
-    greece("greece"),
-    hungary("hungary"),
-    ireland("ireland"),
-    italy("italy"),
-    latvia("latvia"),
-    lithuania("lithuania"),
-    luxembourg("luxembourg"),
-    malta("malta"),
-    netherlands("netherlands"),
-    poland("poland"),
-    portugal("portugal"),
-    romania("romania"),
-    slovakia("slovakia"),
-    slovenia("slovenia"),
-    spain("spain"),
-    sweden("sweden"),
-    united_kingdom("united-kingdom"),
-    iceland("iceland"),
-    liechtestein("liechtestein"),
-    norway("norway");
+    austria("austria", true),
+    belgium("belgium", true),
+    bulgaria("bulgaria", true),
+    croatia("croatia", true),
+    cyprus("cyprus", true),
+    czech_republic("czech-republic", true),
+    denmark("denmark", true),
+    estonia("estonia", true),
+    finland("finland", true),
+    france("france", true),
+    germany("germany", true),
+    greece("greece", true),
+    hungary("hungary", true),
+    ireland("ireland", true),
+    italy("italy", true),
+    latvia("latvia", true),
+    lithuania("lithuania", true),
+    luxembourg("luxembourg", true),
+    malta("malta", true),
+    netherlands("netherlands", true),
+    poland("poland", true),
+    portugal("portugal", true),
+    romania("romania", true),
+    slovakia("slovakia", true),
+    slovenia("slovenia", true),
+    spain("spain", false), // unsigned assertions
+    sweden("sweden", true),
+    united_kingdom("united-kingdom", true),
+    iceland("iceland", true),
+    liechtestein("liechtestein", true),
+    norway("norway", true);
 
     private String eidasSchemeName;
+    private boolean shouldSignAssertions;
 
-    EidasScheme(String eidasSchemeName) {
+    EidasScheme(String eidasSchemeName, boolean shouldSignAssertions) {
         this.eidasSchemeName = eidasSchemeName;
+        this.shouldSignAssertions = shouldSignAssertions;
     }
 
     public String getEidasSchemeName() {
         return eidasSchemeName;
     }
+    public boolean getSignsAssertions() { return shouldSignAssertions; }
 
     public static Optional<EidasScheme> fromString(String eidasSchemeName) {
         for(EidasScheme eidasScheme : values()) {

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/EidasScheme.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/EidasScheme.java
@@ -6,44 +6,48 @@ import java.util.Optional;
  * This can't be used to read path params directly as we are using params with dashes
  */
 public enum EidasScheme {
-    stub_country("stub-country", true),
+    stub_country("stub-country"),
     stub_country_unsigned_assertions("stub-country-unsigned-assertions", false),
-    stub_cef_reference("stub-cef-reference", true),
+    stub_cef_reference("stub-cef-reference"),
 
-    austria("austria", true),
-    belgium("belgium", true),
-    bulgaria("bulgaria", true),
-    croatia("croatia", true),
-    cyprus("cyprus", true),
-    czech_republic("czech-republic", true),
-    denmark("denmark", true),
-    estonia("estonia", true),
-    finland("finland", true),
-    france("france", true),
-    germany("germany", true),
-    greece("greece", true),
-    hungary("hungary", true),
-    ireland("ireland", true),
-    italy("italy", true),
-    latvia("latvia", true),
-    lithuania("lithuania", true),
-    luxembourg("luxembourg", true),
-    malta("malta", true),
-    netherlands("netherlands", true),
-    poland("poland", true),
-    portugal("portugal", true),
-    romania("romania", true),
-    slovakia("slovakia", true),
-    slovenia("slovenia", true),
-    spain("spain", false), // unsigned assertions
-    sweden("sweden", true),
-    united_kingdom("united-kingdom", true),
-    iceland("iceland", true),
-    liechtestein("liechtestein", true),
-    norway("norway", true);
+    austria("austria"),
+    belgium("belgium"),
+    bulgaria("bulgaria"),
+    croatia("croatia"),
+    cyprus("cyprus"),
+    czech_republic("czech-republic"),
+    denmark("denmark"),
+    estonia("estonia"),
+    finland("finland"),
+    france("france"),
+    germany("germany"),
+    greece("greece"),
+    hungary("hungary"),
+    ireland("ireland"),
+    italy("italy"),
+    latvia("latvia"),
+    lithuania("lithuania"),
+    luxembourg("luxembourg"),
+    malta("malta"),
+    netherlands("netherlands"),
+    poland("poland"),
+    portugal("portugal"),
+    romania("romania"),
+    slovakia("slovakia"),
+    slovenia("slovenia"),
+    spain("spain", false),
+    sweden("sweden"),
+    united_kingdom("united-kingdom"),
+    iceland("iceland"),
+    liechtestein("liechtestein"),
+    norway("norway");
 
     private String eidasSchemeName;
     private boolean shouldSignAssertions;
+
+    EidasScheme(String eidasSchemeName) {
+        this(eidasSchemeName, true);
+    }
 
     EidasScheme(String eidasSchemeName, boolean shouldSignAssertions) {
         this.eidasSchemeName = eidasSchemeName;

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubCoreTransformersFactory.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubCoreTransformersFactory.java
@@ -24,17 +24,6 @@ import uk.gov.ida.stub.idp.transformers.UnsignedAssertionCapableResponseToSigned
  */
 public class StubCoreTransformersFactory {
 
-    static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
-        final EncryptionKeyStore publicKeyStore,
-        final IdaKeyStore keyStore,
-        final EntityToEncryptForLocator entityToEncryptForLocator,
-        final SignatureAlgorithm signatureAlgorithm,
-        final DigestAlgorithm digestAlgorithm,
-        final boolean signAssertions) {
-        return getResponseStringTransformer(publicKeyStore, keyStore, entityToEncryptForLocator, signatureAlgorithm,
-            digestAlgorithm, new EncrypterFactory(), signAssertions);
-    }
-
     public static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
         final EncryptionKeyStore publicKeyStore,
         final IdaKeyStore keyStore,
@@ -43,50 +32,20 @@ public class StubCoreTransformersFactory {
         final DigestAlgorithm digestAlgorithm,
         final EncrypterFactory encrypterFactory,
         final boolean signAssertions) {
-        SignatureFactory signatureFactory = new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm);
+
+        SignatureFactory signatureFactory = new SignatureFactory(
+            new IdaKeyStoreCredentialRetriever(keyStore),
+            signatureAlgorithm,
+            digestAlgorithm);
+
         ResponseAssertionSigner responseAssertionSigner = new ResponseAssertionSigner(signatureFactory);
-        return getResponseStringTransformer(publicKeyStore, entityToEncryptForLocator, encrypterFactory, signatureFactory, responseAssertionSigner, signAssertions);
-    }
 
-    static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
-        final EncryptionKeyStore encryptionKeyStore,
-        final IdaKeyStore keyStore,
-        final EntityToEncryptForLocator entityToEncryptForLocator,
-        final String publicSigningKey,
-        final String issuerId,
-        final SignatureAlgorithm signatureAlgorithm,
-        final DigestAlgorithm digestAlgorithm,
-        final boolean signAssertions
-    ) {
-        SignatureFactory signatureFactory = new SignatureWithKeyInfoFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm, issuerId, publicSigningKey);
-        ResponseAssertionSigner responseAssertionSigner = new ResponseAssertionSigner(signatureFactory);
-        return getResponseStringTransformer(encryptionKeyStore, entityToEncryptForLocator, new EncrypterFactory(), signatureFactory, responseAssertionSigner, signAssertions);
-    }
-
-    static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
-        final EncryptionKeyStore publicKeyStore,
-        final IdaKeyStore keyStore,
-        final EntityToEncryptForLocator entityToEncryptForLocator,
-        final ResponseAssertionSigner responseAssertionSigner,
-        final SignatureAlgorithm signatureAlgorithm,
-        final DigestAlgorithm digestAlgorithm,
-        final boolean signAssertions) {
-        SignatureFactory signatureFactory = new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm);
-        return getResponseStringTransformer(publicKeyStore, entityToEncryptForLocator, new EncrypterFactory(), signatureFactory, responseAssertionSigner, signAssertions);
-    }
-
-    private static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
-        final EncryptionKeyStore publicKeyStore,
-        final EntityToEncryptForLocator entityToEncryptForLocator,
-        final EncrypterFactory encrypterFactory,
-        final SignatureFactory signatureFactory,
-        final ResponseAssertionSigner responseAssertionSigner,
-        final boolean signAssertions) {
         SamlResponseAssertionEncrypter responseAssertionEncrypter =
             new SamlResponseAssertionEncrypter(
                 new KeyStoreBackedEncryptionCredentialResolver(publicKeyStore),
                 encrypterFactory,
                 entityToEncryptForLocator);
+
         return new UnsignedAssertionCapableResponseToSignedStringTransformer(
             new XmlObjectToBase64EncodedStringTransformer<>(),
             new SamlSignatureSigner<>(),

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubCoreTransformersFactory.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubCoreTransformersFactory.java
@@ -1,0 +1,101 @@
+package uk.gov.ida.stub.idp.domain.factories;
+
+import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseSignatureCreator;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlResponseAssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.security.EncrypterFactory;
+import uk.gov.ida.saml.security.EncryptionKeyStore;
+import uk.gov.ida.saml.security.EntityToEncryptForLocator;
+import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.saml.security.IdaKeyStoreCredentialRetriever;
+import uk.gov.ida.saml.security.KeyStoreBackedEncryptionCredentialResolver;
+import uk.gov.ida.saml.security.SignatureFactory;
+import uk.gov.ida.saml.security.SignatureWithKeyInfoFactory;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+import uk.gov.ida.stub.idp.transformers.UnsignedAssertionCapableResponseToSignedStringTransformer;
+
+/**
+ * Replaces <i>some</i> calls that would have been made to CoreTransformersFactory in saml-libs - in particular,
+ * provides a ResponseStringTransformer that can optionally skip signing of assertions: essential for stub countries
+ * (but not much else).
+ */
+public class StubCoreTransformersFactory {
+
+    static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
+        final EncryptionKeyStore publicKeyStore,
+        final IdaKeyStore keyStore,
+        final EntityToEncryptForLocator entityToEncryptForLocator,
+        final SignatureAlgorithm signatureAlgorithm,
+        final DigestAlgorithm digestAlgorithm,
+        final boolean signAssertions) {
+        return getResponseStringTransformer(publicKeyStore, keyStore, entityToEncryptForLocator, signatureAlgorithm,
+            digestAlgorithm, new EncrypterFactory(), signAssertions);
+    }
+
+    public static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
+        final EncryptionKeyStore publicKeyStore,
+        final IdaKeyStore keyStore,
+        final EntityToEncryptForLocator entityToEncryptForLocator,
+        final SignatureAlgorithm signatureAlgorithm,
+        final DigestAlgorithm digestAlgorithm,
+        final EncrypterFactory encrypterFactory,
+        final boolean signAssertions) {
+        SignatureFactory signatureFactory = new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm);
+        ResponseAssertionSigner responseAssertionSigner = new ResponseAssertionSigner(signatureFactory);
+        return getResponseStringTransformer(publicKeyStore, entityToEncryptForLocator, encrypterFactory, signatureFactory, responseAssertionSigner, signAssertions);
+    }
+
+    static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
+        final EncryptionKeyStore encryptionKeyStore,
+        final IdaKeyStore keyStore,
+        final EntityToEncryptForLocator entityToEncryptForLocator,
+        final String publicSigningKey,
+        final String issuerId,
+        final SignatureAlgorithm signatureAlgorithm,
+        final DigestAlgorithm digestAlgorithm,
+        final boolean signAssertions
+    ) {
+        SignatureFactory signatureFactory = new SignatureWithKeyInfoFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm, issuerId, publicSigningKey);
+        ResponseAssertionSigner responseAssertionSigner = new ResponseAssertionSigner(signatureFactory);
+        return getResponseStringTransformer(encryptionKeyStore, entityToEncryptForLocator, new EncrypterFactory(), signatureFactory, responseAssertionSigner, signAssertions);
+    }
+
+    static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
+        final EncryptionKeyStore publicKeyStore,
+        final IdaKeyStore keyStore,
+        final EntityToEncryptForLocator entityToEncryptForLocator,
+        final ResponseAssertionSigner responseAssertionSigner,
+        final SignatureAlgorithm signatureAlgorithm,
+        final DigestAlgorithm digestAlgorithm,
+        final boolean signAssertions) {
+        SignatureFactory signatureFactory = new SignatureFactory(new IdaKeyStoreCredentialRetriever(keyStore), signatureAlgorithm, digestAlgorithm);
+        return getResponseStringTransformer(publicKeyStore, entityToEncryptForLocator, new EncrypterFactory(), signatureFactory, responseAssertionSigner, signAssertions);
+    }
+
+    private static UnsignedAssertionCapableResponseToSignedStringTransformer getResponseStringTransformer(
+        final EncryptionKeyStore publicKeyStore,
+        final EntityToEncryptForLocator entityToEncryptForLocator,
+        final EncrypterFactory encrypterFactory,
+        final SignatureFactory signatureFactory,
+        final ResponseAssertionSigner responseAssertionSigner,
+        final boolean signAssertions) {
+        SamlResponseAssertionEncrypter responseAssertionEncrypter =
+            new SamlResponseAssertionEncrypter(
+                new KeyStoreBackedEncryptionCredentialResolver(publicKeyStore),
+                encrypterFactory,
+                entityToEncryptForLocator);
+        return new UnsignedAssertionCapableResponseToSignedStringTransformer(
+            new XmlObjectToBase64EncodedStringTransformer<>(),
+            new SamlSignatureSigner<>(),
+            responseAssertionEncrypter,
+            responseAssertionSigner,
+            new ResponseSignatureCreator(signatureFactory),
+            signAssertions
+        );
+    }
+
+
+}

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubTransformersFactory.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubTransformersFactory.java
@@ -23,6 +23,7 @@ import uk.gov.ida.saml.security.SigningKeyStore;
 import uk.gov.ida.stub.idp.domain.IdpIdaStatusMarshaller;
 import uk.gov.ida.stub.idp.domain.OutboundResponseFromIdp;
 import uk.gov.ida.stub.idp.saml.transformers.OutboundResponseFromIdpToSamlResponseTransformer;
+import uk.gov.ida.stub.idp.transformers.UnsignedAssertionCapableResponseToSignedStringTransformer;
 
 import java.util.function.Function;
 
@@ -67,7 +68,6 @@ public class StubTransformersFactory {
             SignatureAlgorithm signatureAlgorithm,
             DigestAlgorithm digestAlgorithm
     ){
-
         return coreTransformersFactory.getResponseStringTransformer(
                 publicKeyStore,
                 keyStore,

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubTransformersFactory.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/domain/factories/StubTransformersFactory.java
@@ -23,7 +23,6 @@ import uk.gov.ida.saml.security.SigningKeyStore;
 import uk.gov.ida.stub.idp.domain.IdpIdaStatusMarshaller;
 import uk.gov.ida.stub.idp.domain.OutboundResponseFromIdp;
 import uk.gov.ida.stub.idp.saml.transformers.OutboundResponseFromIdpToSamlResponseTransformer;
-import uk.gov.ida.stub.idp.transformers.UnsignedAssertionCapableResponseToSignedStringTransformer;
 
 import java.util.function.Function;
 

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/saml/transformers/EidasResponseTransformerProvider.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/saml/transformers/EidasResponseTransformerProvider.java
@@ -9,6 +9,7 @@ import uk.gov.ida.saml.security.EncrypterFactory;
 import uk.gov.ida.saml.security.EncryptionKeyStore;
 import uk.gov.ida.saml.security.EntityToEncryptForLocator;
 import uk.gov.ida.saml.security.IdaKeyStore;
+import uk.gov.ida.stub.idp.domain.factories.StubCoreTransformersFactory;
 
 import java.util.function.Function;
 
@@ -36,6 +37,17 @@ public class EidasResponseTransformerProvider {
         this.digestAlgorithm = digestAlgorithm;
     }
 
+    public Function<Response, String> getTransformer(boolean signAssertions){
+        return StubCoreTransformersFactory.getResponseStringTransformer(
+            encryptionKeyStore,
+            keyStore,
+            entityToEncryptForLocator,
+            signatureAlgorithm,
+            digestAlgorithm,
+            new EncrypterFactory().withDataEncryptionAlgorithm(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM),
+            signAssertions);
+    }
+
     public Function<Response, String> getTransformer(){
         return coreTransformersFactory.getResponseStringTransformer(
                 encryptionKeyStore,
@@ -43,6 +55,7 @@ public class EidasResponseTransformerProvider {
                 entityToEncryptForLocator,
                 signatureAlgorithm,
                 digestAlgorithm,
-                new EncrypterFactory().withDataEncryptionAlgorithm(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM));
+                new EncrypterFactory().withDataEncryptionAlgorithm(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM)
+        ); // default behaviour is to sign assertions for backwards compatibility
     }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/saml/transformers/EidasResponseTransformerProvider.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/saml/transformers/EidasResponseTransformerProvider.java
@@ -3,7 +3,6 @@ package uk.gov.ida.stub.idp.saml.transformers;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.xmlsec.algorithm.DigestAlgorithm;
 import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
-import org.opensaml.xmlsec.encryption.support.EncryptionConstants;
 import uk.gov.ida.saml.core.api.CoreTransformersFactory;
 import uk.gov.ida.saml.security.EncrypterFactory;
 import uk.gov.ida.saml.security.EncryptionKeyStore;
@@ -12,6 +11,8 @@ import uk.gov.ida.saml.security.IdaKeyStore;
 import uk.gov.ida.stub.idp.domain.factories.StubCoreTransformersFactory;
 
 import java.util.function.Function;
+
+import static org.opensaml.xmlsec.encryption.support.EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM;
 
 public class EidasResponseTransformerProvider {
 
@@ -44,7 +45,7 @@ public class EidasResponseTransformerProvider {
             entityToEncryptForLocator,
             signatureAlgorithm,
             digestAlgorithm,
-            new EncrypterFactory().withDataEncryptionAlgorithm(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM),
+            new EncrypterFactory().withDataEncryptionAlgorithm(ALGO_ID_BLOCKCIPHER_AES256_GCM),
             signAssertions);
     }
 
@@ -55,7 +56,7 @@ public class EidasResponseTransformerProvider {
                 entityToEncryptForLocator,
                 signatureAlgorithm,
                 digestAlgorithm,
-                new EncrypterFactory().withDataEncryptionAlgorithm(EncryptionConstants.ALGO_ID_BLOCKCIPHER_AES256_GCM)
+                new EncrypterFactory().withDataEncryptionAlgorithm(ALGO_ID_BLOCKCIPHER_AES256_GCM)
         ); // default behaviour is to sign assertions for backwards compatibility
     }
 }

--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/transformers/UnsignedAssertionCapableResponseToSignedStringTransformer.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/transformers/UnsignedAssertionCapableResponseToSignedStringTransformer.java
@@ -1,0 +1,58 @@
+package uk.gov.ida.stub.idp.transformers;
+
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.xml.signature.P;
+import uk.gov.ida.saml.core.transformers.outbound.ResponseToSignedStringTransformer;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseAssertionSigner;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.ResponseSignatureCreator;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlResponseAssertionEncrypter;
+import uk.gov.ida.saml.core.transformers.outbound.decorators.SamlSignatureSigner;
+import uk.gov.ida.saml.serializers.XmlObjectToBase64EncodedStringTransformer;
+
+import javax.inject.Inject;
+import java.util.function.Function;
+
+/**
+ * Very similar to ResponseToSignedStringTransformer, but does not form a part of the saml-libs:
+ * The capability to generate SAML with unsigned assertions is <u>only</u> required by the stub-idp.
+ */
+public class UnsignedAssertionCapableResponseToSignedStringTransformer implements Function<Response, String> {
+
+    private final XmlObjectToBase64EncodedStringTransformer<?> xmlObjectToBase64EncodedStringTransformer;
+    private final SamlSignatureSigner<Response> samlSignatureSigner;
+    private final SamlResponseAssertionEncrypter samlResponseAssertionEncrypter;
+    private final ResponseAssertionSigner responseAssertionSigner;
+    private final ResponseSignatureCreator responseSignatureCreator;
+    private final boolean signAssertions;
+
+    @Inject
+    public UnsignedAssertionCapableResponseToSignedStringTransformer(
+        XmlObjectToBase64EncodedStringTransformer<?> xmlObjectToBase64EncodedStringTransformer,
+        SamlSignatureSigner<Response> samlSignatureSigner,
+        SamlResponseAssertionEncrypter samlResponseAssertionEncrypter,
+        ResponseAssertionSigner responseAssertionSigner,
+        ResponseSignatureCreator responseSignatureCreator,
+        boolean signAssertions) {
+        this.xmlObjectToBase64EncodedStringTransformer = xmlObjectToBase64EncodedStringTransformer;
+        this.samlSignatureSigner = samlSignatureSigner;
+        this.samlResponseAssertionEncrypter = samlResponseAssertionEncrypter;
+        this.responseAssertionSigner = responseAssertionSigner;
+        this.responseSignatureCreator = responseSignatureCreator;
+        this.signAssertions = signAssertions;
+    }
+
+    @Override
+    public String apply(final Response response) {
+        final Response responseWithSignature = responseSignatureCreator.addUnsignedSignatureTo(response);
+        if (signAssertions) {
+            final Response assertionSignedResponse = responseAssertionSigner.signAssertions(responseWithSignature);
+            final Response encryptedAssertionResponse = samlResponseAssertionEncrypter.encryptAssertions(assertionSignedResponse);
+            final Response signedResponse = samlSignatureSigner.sign(encryptedAssertionResponse);
+            return xmlObjectToBase64EncodedStringTransformer.apply(signedResponse);
+        } else {
+            final Response encryptedAssertionResponse = samlResponseAssertionEncrypter.encryptAssertions(responseWithSignature);
+            final Response signedResponse = samlSignatureSigner.sign(encryptedAssertionResponse);
+            return xmlObjectToBase64EncodedStringTransformer.apply(signedResponse);
+        }
+    }
+}


### PR DESCRIPTION
This pull request is part of a group of 5, made across the following verify repositories, containing adjustments to enable **stub-idp** to support an additional country: `stub-country-unsigned-assertions`.

As the name suggests, `stub-country-unsigned-assertions` generates SAML messages with unsigned assertions.

* **verify-stub-idp**
  * Allow stub-idp supported stub countries to differentiate their behaviour by `EidasScheme`.
  * Create `UnsignedAssertionCapableResponseToSignedStringTransformer` and use it in place of `ResponseToSignedStringTransformer` when generating stub-country-unsigned-assertion responses.
* **verify-frontend**
  * Add stub-country-unsigned-assertions to the stub_api.
  * Add country flag (xx).
* **verify-frontend-federation-config**
  * Add scheme, locale, flag, and logo for stub-country-unsigned-assertions (xx).
* **ida-hub-acceptance-tests**
  * Add `STUB_COUNTRY_UA` to `Country` enum.
* **verify-metadata**
  * Add `stub-country-unsigned-assertions` metadata (matching stub country) to `local` environment.