### PR TITLE
ZD-3747417 Fix Stub-IDP address fields

### DIFF
--- a/stub-idp/src/main/java/uk/gov/ida/stub/idp/services/IdpUserService.java
+++ b/stub-idp/src/main/java/uk/gov/ida/stub/idp/services/IdpUserService.java
@@ -101,7 +101,7 @@ public class IdpUserService {
             throw new UsernameAlreadyTakenException();
         }
 
-        Address address = new Address(asList(addressLine1, addressLine2), addressPostCode, null, null, null, null, false);
+        Address address = new Address(asList(addressLine1, addressLine2, addressTown), addressPostCode, null, null, null, null, false);
 
         AuthnContext levelOfAssurance = _levelOfAssurance;
         if ("LevelZeroUser".equals(username)) {


### PR DESCRIPTION
DEFRA Rural Payments Agency couldn't test the Verify matching process because Stub IDP wasn't returning the town as part of the address.  This change adds the town so that matching works properly and DEFRA can more easily test in the integration environment.