### PR TITLE
EID-1611 improve the uniqueness of the id for the sign assertions checkbox

### DIFF
--- a/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/eidasLoginPage.ftl
+++ b/stub-idp/src/main/resources/uk/gov/ida/stub/idp/views/eidasLoginPage.ftl
@@ -32,7 +32,7 @@
                 <em>Note about this field</em>
             </div>
             <div>
-                <input class="medium" type="checkbox" name="${signAssertionsCheckboxGroup}" id="${signAssertionsCheckboxGroup}" value="${signAssertionsCheckboxValue}" checked>Sign assertions</input>
+                <input class="medium" type="checkbox" name="${signAssertionsCheckboxGroup}" id="${signAssertionsCheckboxGroup}_${signAssertionsCheckboxValue}" value="${signAssertionsCheckboxValue}" checked>Sign assertions</input>
             </div>
             <div class="submit">
               <!--  <a class="forgot" href="#">Forgotten Password?</a> -->


### PR DESCRIPTION
This change modifies the id of the sign assertions checkbox to make it meaningful in the context of the name/id/value triplet for HTML checkboxes.

Essential for: https://github.com/alphagov/verify-acceptance-tests/pull/73