### PR TITLE
AUT-14: Rename logit's service name

### DIFF
--- a/manifest.yml.tmpl
+++ b/manifest.yml.tmpl
@@ -37,4 +37,4 @@ applications:
       VERIFY_SUBMISSION_URL: $VERIFY_SUBMISSION_URL
     services:
       - stub-idp-db-$ENV
-      - stub-idp-logit-$ENV
+      - logit-$ENV


### PR DESCRIPTION
This change renames Logit's service name from stub-idp-logit-<environment> to logit-<environment> since Logit service is not just for stub-idp application. It is for all applications running in the environment.

Author: @adityapahuja