### PR TITLE
Stop publishing to artifactory

### DIFF
--- a/stub-idp-saml-test/build.gradle
+++ b/stub-idp-saml-test/build.gradle
@@ -4,16 +4,6 @@ apply plugin: 'maven-publish'
 apply plugin: 'java'
 
 publishing {
-    repositories {
-        maven {
-            credentials {
-                username "${System.env.ARTIUSER}"
-                password "${System.env.ARTIPASSWORD}"
-            }
-            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
-        }
-    }
-
     publications {
         mavenJava(MavenPublication) {
             from components.java

--- a/stub-idp-saml/build.gradle
+++ b/stub-idp-saml/build.gradle
@@ -4,16 +4,6 @@ apply plugin: 'maven-publish'
 apply plugin: 'java'
 
 publishing {
-    repositories {
-        maven {
-            credentials {
-                username "${System.env.ARTIUSER}"
-                password "${System.env.ARTIPASSWORD}"
-            }
-            url "https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/libs-release-local"
-        }
-    }
-
     publications {
         mavenJava(MavenPublication) {
             from components.java

--- a/stub-idp/build.gradle
+++ b/stub-idp/build.gradle
@@ -48,23 +48,6 @@ distZip {
     }
 }
 
-publishing {
-    publications {
-        zipFile(MavenPublication) {
-            artifactId = "ida-stub-idp"
-            version = "${version ?: 'SNAPSHOT'}"
-            groupId = "uk.gov.ida"
-
-            artifact file("build/distributions/${project.name}-${version}.zip")
-        }
-    }
-    repositories {
-        maven {
-            url "/srv/maven"
-        }
-    }
-}
-
 task copyStubIdpLogos(type: Copy) {
     description 'Copy stub idp logos from federation config into the main resource dir'
     if (project.hasProperty('stubidpExtraLogosDirectory')) {


### PR DESCRIPTION
Bintray is the source of truth now, for stub-idp-saml and
stub-idp-saml-test.

Bintray is made available via whitelisted-repos on artifactory, so we
still pull dependencies down using artifactory, but we only need to
push dependencies to bintray.

The exception is stub-idp itself; our artifact store for this is S3;
concourse builds stub-idp and uploads the artifacts to an S3 bucket,
and deploys from there to PaaS.