### PR TITLE
BAU: Increase healthcheck timeout to 120s

### DIFF
--- a/manifest.yml.tmpl
+++ b/manifest.yml.tmpl
@@ -6,6 +6,7 @@ applications:
       - route: idp-stub-$ENV.ida.digital.cabinet-office.gov.uk
     stack: cflinuxfs3
     memory: 1G
+    timeout: 120
     buildpacks:
       - java_buildpack
     env:


### PR DESCRIPTION
This change updates healthcheck timeout from 60s to 120s to resolve the following error.

`ERR Timed out after 1m0s: health check never passed.`

Author: @adityapahuja