### PR TITLE
Give PostgreSQL docker a password

### DIFF
--- a/configuration/local/stub-idp.yml
+++ b/configuration/local/stub-idp.yml
@@ -98,7 +98,7 @@ europeanIdentity:
       name: stub_country_signing_cert
 
 database:
-  url: ${DB_URI:-jdbc:postgresql://localhost:5432/postgres?user=postgres}
+  url: ${DB_URI:-jdbc:postgresql://localhost:5432/postgres?user=postgres&password=docker}
 
 singleIdpJourney:
   enabled: ${SINGLE_IDP_FEATURE:-false}

--- a/startup.sh
+++ b/startup.sh
@@ -19,7 +19,7 @@ build_service ../verify-stub-idp
 if ! docker ps | grep stub-idp-postgres-db >/dev/null
 then
   printf "$(tput setaf 3)Postgres is required for stub-idp, attempting to start postgres using docker.\\n$(tput sgr0)"
-  docker run --rm -d -p 5432:5432 --name stub-idp-postgres-db postgres >/dev/null
+  docker run --rm -d -p 5432:5432 -e POSTGRES_PASSWORD=docker --name stub-idp-postgres-db postgres >/dev/null
 fi
 
 start_service stub-idp ../verify-stub-idp/stub-idp configuration/local/stub-idp.yml $STUB_IDP_PORT


### PR DESCRIPTION
Postgres Docker now requires a password to startup. I don't know how
long this has been a requirement but it has caused me some issues on
Linux and I think I have seen the issue on my mac as well. This commit
fixes that issue.