### PR TITLE
[HUB-841] Use dockerhub rather than ghcr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN gradle :stub-idp:installDist
 ENTRYPOINT ["gradle"]
 CMD ["tasks"]
 
-FROM ghcr.io/alphagov/verify/java:openjdk-11
+FROM openjdk:11.0.9.1-jre
 
 WORKDIR /stub-idp
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,6 +6,8 @@ image_resource:
   source:
     repository: openjdk
     tag: 11-jdk-slim
+    username: ((dockerhub-username))
+    password: ((dockerhub-password))
 
 inputs:
   - name: stub-idp

--- a/smoke-test/Dockerfile
+++ b/smoke-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/alphagov/verify/ruby:2.6.6
+FROM ruby:2.6.6
 
 ADD Gemfile Gemfile
 


### PR DESCRIPTION
We've moved back to using Docker Hub rather than GitHub container registry so un-doing the work that was done 5 months ago. Moved back to versions previously set https://github.com/alphagov/verify-stub-idp/commit/d6266362fbec609dc31f351cefbde01168fce1f0 but might need updating later.