### PR TITLE
Dockerfile missing publish.gradle causing verify-local-startup to fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY stub-idp-saml/build.gradle stub-idp-saml/build.gradle
 COPY shared.gradle shared.gradle
 COPY settings.gradle settings.gradle
 COPY inttest.gradle inttest.gradle
+COPY publish.gradle publish.gradle
 # There is an issue running idea.gradle in the container
 # So just make this an empty file
 RUN touch idea.gradle


### PR DESCRIPTION
When building the dockerfile from verify-local-startup the stub-idp repository doesn't build due to it missing `publish.gradle`. The following is the log taken from verify-local-startup when trying to build this repo:

```
#18 [build 10/14] RUN gradle :stub-idp:install
#18 sha256:95f50bf7d2616ae9f0c6e1eb8555f23c6e36bf3ec29dfd6d8c9a7bd874492267
#18 1.416
#18 1.416 Welcome to Gradle 6.8.3!
#18 1.416
#18 1.416 Here are the highlights of this release:
#18 1.416  - Faster Kotlin DSL script compilation
#18 1.416  - Vendor selection for Java toolchains
#18 1.417  - Convenient execution of tasks in composite builds
#18 1.417  - Consistent dependency resolution
#18 1.417
#18 1.417 For more details see https://docs.gradle.org/6.8.3/release-notes.html
#18 1.417
#18 1.781 Starting a Gradle Daemon (subsequent builds will be faster)
#18 17.55
#18 17.55 FAILURE: Build failed with an exception.
#18 17.55
#18 17.55 * Where:
#18 17.55 Build file '/stub-idp/stub-idp-saml/build.gradle' line: 1
#18 17.55
#18 17.55 * What went wrong:
#18 17.55 A problem occurred evaluating project ':stub-idp-saml'.
#18 17.55 > Could not read script '/stub-idp/publish.gradle' as it does not exist.
#18 17.55
#18 17.56 * Try:
#18 17.56 Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
#18 17.56
#18 17.56 * Get more help at https://help.gradle.org
#18 17.65
#18 17.65 Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
#18 17.65 Use '--warning-mode all' to show the individual deprecation warnings.
#18 17.65 See https://docs.gradle.org/6.8.3/userguide/command_line_interface.html#sec:command_line_warnings
#18 17.65
#18 17.65 BUILD FAILED in 17s
#18 ERROR: executor failed running [/bin/sh -c gradle :stub-idp:install]: exit code: 1
```

You can test it by either rebuilding verify-local-startup or simply cloning down this repository and running docker build.

I added another layer to `COPY` across the file.