### PR TITLE
BAU: Fix distZip artifact name in pipeline

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -32,8 +32,7 @@ run:
       /usr/bin/rsync -qrv "$stub_idp_fed_config/configuration/" stub-idp/stub-idp/src/dist/resources/
       cd stub-idp/stub-idp
       ../gradlew --parallel --no-daemon clean test intTest
-      ../gradlew --no-daemon \
-              -Pversion=$(cat ../../stub-idp-version/number) \
+      BUILD_NUMBER=$(cat ../../stub-idp-version/number) ../gradlew --no-daemon \
               -PstubidpExtraLogosDirectory="$stub_idp_fed_config/idp-logos" \
               copyStubIdpLogos copyToLib distZip
       cp build/distributions/stub-idp-*.zip ../../stub-idp-java


### PR DESCRIPTION
A change was made a while ago so that version used by distZip for naming
was set to the value of `build_version` in the root gradle file.
`build_version` is composed from the open saml version set as well as
the env variable `BUILD_NUMBER`. If `BUILD_NUMBER` is not set then
`SNAPSHOT` is used instead.

This pipeline hasn't been updated to reflect this and so all new
artifacts have the same name - `stub-idp-3.4.3-SNAPSHOT.zip`

This all means that the pipeline doesn't register a new build artifact
as a new version and so it doesn't get released.

Providing the Concourse version number as BUILD_NUMBER ensures each new
build has a unique artifact name and triggers the pipeline correctly.